### PR TITLE
Added `Lam` and more type-ascriptions

### DIFF
--- a/parsley-core/ChangeLog.md
+++ b/parsley-core/ChangeLog.md
@@ -4,3 +4,8 @@
 
 * First version. Released on an unsuspecting world.
 * Core factored out of the main `parsley` package
+
+## 1.0.1.0 -- 2021-06-26
+
+* Introduced `Lam` to the API and conversion functions for `Core.Defunc`
+* Extra type ascriptions added to generated code

--- a/parsley-core/parsley-core.cabal
+++ b/parsley-core/parsley-core.cabal
@@ -5,7 +5,7 @@ name:                parsley-core
 --                   | +------- breaking internal API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             1.0.0.0
+version:             1.0.1.0
 synopsis:            A fast parser combinator library backed by Typed Template Haskell
 description:         This package contains the internals of the @parsley@ package.
                      .

--- a/parsley-core/parsley-core.cabal
+++ b/parsley-core/parsley-core.cabal
@@ -49,6 +49,7 @@ library
                        Parsley.Internal.Core.Defunc,
                        Parsley.Internal.Core.Identifiers,
                        Parsley.Internal.Core.InputTypes,
+                       Parsley.Internal.Core.Lam,
                        Parsley.Internal.Core.Primitives,
 
                        Parsley.Internal.Frontend,

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Ops.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Ops.hs
@@ -62,6 +62,7 @@ emitLengthCheck (I# n) good bad γ = [||
 
 {- General Operations -}
 dup :: Defunc x -> (Defunc x -> Code r) -> Code r
+dup (FREEVAR x) k = k (FREEVAR x)
 dup x k = [|| let !dupx = $$(genDefunc x) in $$(k (FREEVAR [||dupx||])) ||]
 
 {-# INLINE returnST #-}

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Ops.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Ops.hs
@@ -135,7 +135,7 @@ resume k γ = let Op x _ = operands γ in [|| $$k $$(genDefunc x) $$(input γ) |
 #define deriveContOps(_o)                                                              \
 instance ContOps _o where                                                              \
 {                                                                                      \
-  suspend m γ = [|| \x (!o#) -> $$(m (γ {operands = Op (FREEVAR [||x||]) (operands γ), \
+  suspend m γ = [|| \x !(o# :: Rep _o) -> $$(m (γ {operands = Op (FREEVAR [||x||]) (operands γ), \
                                          input = [||o#||]})) ||];                      \
 };
 inputInstances(deriveContOps)
@@ -177,15 +177,15 @@ inputInstances(deriveJoinBuilder)
 instance RecBuilder _o where                                                \
 {                                                                           \
   buildIter ctx μ l h o = [||                                               \
-      let handler !o# = $$(h [||o#||]);                                     \
-          loop !o# =                                                        \
+      let handler !(o# :: Rep _o) = $$(h [||o#||]);                                     \
+          loop !(o# :: Rep _o) =                                                        \
         $$(run l                                                            \
             (Γ Empty (noreturn @_o) [||o#||] (VCons [||handler o#||] VNil)) \
-            (voidCoins (insertSub μ [||\_ (!o#) _ -> loop o#||] ctx)))      \
+            (voidCoins (insertSub μ [||\_ !(o# :: Rep _o) _ -> loop o#||] ctx)))      \
       in loop $$o                                                           \
     ||];                                                                    \
   buildRec rs ctx k = takeFreeRegisters rs ctx (\ctx ->                     \
-    [|| \(!ret) (!o#) h ->                                                  \
+    [|| \(!ret) !(o# :: Rep _o) h ->                                                  \
       $$(run k (Γ Empty [||ret||] [||o#||] (VCons [||h||] VNil)) ctx) ||]); \
 };
 inputInstances(deriveRecBuilder)
@@ -220,7 +220,7 @@ preludeString name dir γ ctx ends = [|| concat [$$prelude, $$eof, ends, '\n' : 
 #define deriveLogHandler(_o)                                                                   \
 instance LogHandler _o where                                                                   \
 {                                                                                              \
-  logHandler name ctx γ _ = let VCons h _ = handlers γ in [||\(!o#) ->                         \
+  logHandler name ctx γ _ = let VCons h _ = handlers γ in [||\ !(o# :: Rep _o) ->                         \
       trace $$(preludeString name '<' (γ {input = [||o#||]}) ctx (color Red " Fail")) ($$h o#) \
     ||];                                                                                       \
 };

--- a/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Defunc.hs
+++ b/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Defunc.hs
@@ -1,9 +1,9 @@
 module Parsley.Internal.Backend.Machine.Defunc (module Parsley.Internal.Backend.Machine.Defunc) where
 
 import Parsley.Internal.Backend.Machine.InputOps (PositionOps(same))
-import Parsley.Internal.Common.Utils             (Code, WQ(WQ))
+import Parsley.Internal.Common.Utils             (Code)
 
-import qualified Parsley.Internal.Core.Defunc as Core (Defunc(BLACK), ap, genDefunc, genDefunc1, genDefunc2)
+import qualified Parsley.Internal.Core.Defunc as Core (Defunc, ap, genDefunc, genDefunc1, genDefunc2, unsafeBLACK)
 
 data Defunc a where
   USER    :: Core.Defunc a -> Defunc a
@@ -16,7 +16,7 @@ ap2 f x y = USER (Core.ap (Core.ap (seal f) (seal x)) (seal y))
   where
     seal :: Defunc a -> Core.Defunc a
     seal (USER x) = x
-    seal x        = Core.BLACK (WQ undefined (genDefunc x))
+    seal x        = Core.unsafeBLACK (genDefunc x)
 
 genDefunc :: Defunc a -> Code a
 genDefunc (USER x)    = Core.genDefunc x

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/CodeGenerator.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/CodeGenerator.hs
@@ -60,10 +60,10 @@ peephole (f :<$>: p) = Just $ CodeGen $ \m -> runCodeGen p (In4 (Fmap (USER f) m
 peephole (LiftA2 f p q) = Just $ CodeGen $ \m ->
   do qc <- runCodeGen q (In4 (Lift2 (USER f) m))
      runCodeGen p qc
-peephole (TryOrElse p q) = Just $ CodeGen $ \m -> -- FIXME!
+{-peephole (TryOrElse p q) = Just $ CodeGen $ \m -> -- FIXME!
   do (binder, φ) <- makeΦ m
      pc <- freshΦ (runCodeGen p (deadCommitOptimisation φ))
-     fmap (binder . In4 . Catch pc . In4 . Seek) (freshΦ (runCodeGen q φ))
+     fmap (binder . In4 . Catch pc . In4 . Seek) (freshΦ (runCodeGen q φ))-}
 peephole ((_ :< (Try (p :< _) :$>: x)) :<|>: (q :< _)) = Just $ CodeGen $ \m ->
   do (binder, φ) <- makeΦ m
      pc <- freshΦ (runCodeGen p (deadCommitOptimisation (In4 (Pop (In4 (Push (USER x) φ))))))

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/CodeGenerator.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/CodeGenerator.hs
@@ -46,8 +46,8 @@ pattern (:$>:) :: Combinator (Cofree Combinator k) a -> Core.Defunc b -> Combina
 pattern p :$>: x <- (_ :< p) :*>: (_ :< Pure x)
 pattern LiftA2 :: Core.Defunc (a -> b -> c) -> k a -> k b -> Combinator (Cofree Combinator k) c
 pattern LiftA2 f p q <- (_ :< ((_ :< Pure f) :<*>: (p :< _))) :<*>: (q :< _)
-pattern TryOrElse ::  k a -> k a -> Combinator (Cofree Combinator k) a
-pattern TryOrElse p q <- (_ :< Try (p :< _)) :<|>: (q :< _)
+--pattern TryOrElse ::  k a -> k a -> Combinator (Cofree Combinator k) a
+--pattern TryOrElse p q <- (_ :< Try (p :< _)) :<|>: (q :< _)
 
 rollbackHandler :: Fix4 (Instr o) (o : xs) (Succ n) r a
 rollbackHandler = In4 (Seek (In4 Empt))

--- a/parsley-core/src/ghc/Parsley/Internal/Core.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core.hs
@@ -14,6 +14,6 @@ module Parsley.Internal.Core (
     module Parsley.Internal.Core.InputTypes
   ) where
 
-import Parsley.Internal.Core.Defunc hiding (genDefunc, genDefunc1, genDefunc2, ap)
+import Parsley.Internal.Core.Defunc hiding (genDefunc, genDefunc1, genDefunc2, ap, unsafeBLACK, lamTerm, adaptLam)
 import Parsley.Internal.Core.InputTypes
 import Parsley.Internal.Core.Primitives (Parser, ParserOps)

--- a/parsley-core/src/ghc/Parsley/Internal/Core/Defunc.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/Defunc.hs
@@ -79,7 +79,7 @@ instance Quapplicative Defunc where
   _val (IF_S c t e) = if _val c then _val t else _val e
   _val (LAM_S f)    = \x -> _val (f (makeQ x undefined))
   _val (LET_S x f)  = let y = _val x in _val (f (makeQ y undefined))
-  _code = genDefunc
+  _code = normaliseGen . lamTerm
   (>*<) = APP_H
 
 {-|

--- a/parsley-core/src/ghc/Parsley/Internal/Core/Defunc.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/Defunc.hs
@@ -3,7 +3,7 @@ module Parsley.Internal.Core.Defunc (module Parsley.Internal.Core.Defunc) where
 
 import Language.Haskell.TH.Syntax (Lift(..))
 import Parsley.Internal.Common.Utils (WQ(..), Code, Quapplicative(..))
-import Parsley.Internal.Core.Lam (reduceAndGen, Lam(..))
+import Parsley.Internal.Core.Lam (normaliseGen, Lam(..))
 
 {-|
 This datatype is useful for providing an /inspectable/ representation of common Haskell functions.
@@ -142,7 +142,7 @@ adaptLam f = lamTerm . f . defuncTerm
     defuncTerm F          = LIFTED False
 
 genDefunc :: Defunc a -> Code a
-genDefunc = reduceAndGen . lamTerm
+genDefunc = normaliseGen . lamTerm
 
 genDefunc1 :: Defunc (a -> b) -> Code a -> Code b
 genDefunc1 f x = genDefunc (APP_H f (unsafeBLACK x))

--- a/parsley-core/src/ghc/Parsley/Internal/Core/Lam.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/Lam.hs
@@ -5,36 +5,48 @@ import Parsley.Internal.Common.Utils (Code)
 data Lam a where
     Abs :: (Lam a -> Lam b) -> Lam (a -> b)
     App :: Lam (a -> b) -> Lam a -> Lam b
-    Var :: Code a -> Lam a
+    Var :: Bool {- Simple -} -> Code a -> Lam a
     If  :: Lam Bool -> Lam a -> Lam a -> Lam a
     Let :: Lam a -> (Lam a -> Lam b) -> Lam b
+    T   :: Lam Bool
+    F   :: Lam Bool
 
-instance Show (Lam a) where
-    show (Abs _) = "(Abs f)"
-    show (App f x) = "(App " ++ show f ++ " " ++ show x ++ ")"
-    show (Var _) = "(Var x)"
-    show (If c t e) = "(If " ++ show c ++ " " ++ show t ++ " " ++ show e ++ ")"
-    show (Let x _) = "(Let " ++ show x ++ " f)"
-
--- TODO: This needs improving, it's quite brittle at the moment!
-reduce :: Lam a -> Lam a
-reduce = fst . reduce'
+normalise :: Lam a -> Lam a
+normalise x = reduce x
   where
-      reduce' :: Lam a -> (Lam a, Bool)
-      reduce' (App (Abs f) x)       = reduce' (f x)
-      reduce' (App (Var f) (Var x)) = (App (Var f) (Var x), True)
-      reduce' (App (Var f) x)       = let (x', stuck) = reduce' x in (App (Var f) x', stuck)
-      reduce' (App f x)             = let (f', stuck) = reduce' f in if stuck then (App f' x, True) else reduce' (App f' x)
-      reduce' (Abs f)               = (Abs f, False)
-      reduce' x                     = (x, True)
+    reduce :: Lam a -> Lam a
+    reduce x
+      | normal x = x
+      | otherwise = reduce (reduceStep x)
+
+    reduceStep :: Lam a -> Lam a
+    reduceStep (App (Abs f) x) = f x
+    reduceStep (App f x)
+      | normal f = App f (reduceStep x)
+      | otherwise = App (reduceStep f) x
+    reduceStep (If T x _) = x
+    reduceStep (If F _ y) = y
+    reduceStep x = x
+
+    normal :: Lam a -> Bool
+    normal (App (Abs _) _) = False
+    normal (App f x) = normal f && normal x
+    normal (If T _ _) = False
+    normal (If F _ _) = False
+    normal _ = True
+
+reduce :: Lam a -> Lam a
+reduce = normalise
 
 generate :: Lam a -> Code a
-generate (Abs f) = [||\x -> $$(reduceAndGen (f (Var [||x||])))||]
+generate (Abs f)    = [||\x -> $$(reduceAndGen (f (Var True [||x||])))||]
 -- These have already been reduced, since we only expose `reduceAndGen`
-generate (App f x) = [||$$(generate f) $$(generate x)||]
-generate (Var x) = x
+generate (App f x)  = [||$$(generate f) $$(generate x)||]
+generate (Var _ x)  = x
 generate (If c t e) = [||if $$(reduceAndGen c) then $$(reduceAndGen t) else $$(reduceAndGen e)||]
-generate (Let b i) = [||let x = $$(reduceAndGen b) in $$(reduceAndGen (i (Var [||x||])))||]
+generate (Let b i)  = [||let x = $$(reduceAndGen b) in $$(reduceAndGen (i (Var True [||x||])))||]
+generate T          = [||True||]
+generate F          = [||False||]
 
 reduceAndGen :: Lam a -> Code a
 reduceAndGen = generate . reduce

--- a/parsley-core/src/ghc/Parsley/Internal/Core/Lam.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/Lam.hs
@@ -1,4 +1,4 @@
-module Parsley.Internal.Core.Lam (reduceAndGen, Lam(..)) where
+module Parsley.Internal.Core.Lam (normaliseGen, Lam(..)) where
 
 import Parsley.Internal.Common.Utils (Code)
 
@@ -35,18 +35,15 @@ normalise x = reduce x
     normal (If F _ _) = False
     normal _ = True
 
-reduce :: Lam a -> Lam a
-reduce = normalise
-
 generate :: Lam a -> Code a
-generate (Abs f)    = [||\x -> $$(reduceAndGen (f (Var True [||x||])))||]
--- These have already been reduced, since we only expose `reduceAndGen`
+generate (Abs f)    = [||\x -> $$(normaliseGen (f (Var True [||x||])))||]
+-- These have already been reduced, since we only expose `normaliseGen`
 generate (App f x)  = [||$$(generate f) $$(generate x)||]
 generate (Var _ x)  = x
-generate (If c t e) = [||if $$(reduceAndGen c) then $$(reduceAndGen t) else $$(reduceAndGen e)||]
-generate (Let b i)  = [||let x = $$(reduceAndGen b) in $$(reduceAndGen (i (Var True [||x||])))||]
+generate (If c t e) = [||if $$(normaliseGen c) then $$(normaliseGen t) else $$(normaliseGen e)||]
+generate (Let b i)  = [||let x = $$(normaliseGen b) in $$(normaliseGen (i (Var True [||x||])))||]
 generate T          = [||True||]
 generate F          = [||False||]
 
-reduceAndGen :: Lam a -> Code a
-reduceAndGen = generate . reduce
+normaliseGen :: Lam a -> Code a
+normaliseGen = generate . normalise

--- a/parsley-core/src/ghc/Parsley/Internal/Core/Lam.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/Lam.hs
@@ -1,0 +1,40 @@
+module Parsley.Internal.Core.Lam (reduceAndGen, Lam(..)) where
+
+import Parsley.Internal.Common.Utils (Code)
+
+data Lam a where
+    Abs :: (Lam a -> Lam b) -> Lam (a -> b)
+    App :: Lam (a -> b) -> Lam a -> Lam b
+    Var :: Code a -> Lam a
+    If  :: Lam Bool -> Lam a -> Lam a -> Lam a
+    Let :: Lam a -> (Lam a -> Lam b) -> Lam b
+
+instance Show (Lam a) where
+    show (Abs _) = "(Abs f)"
+    show (App f x) = "(App " ++ show f ++ " " ++ show x ++ ")"
+    show (Var _) = "(Var x)"
+    show (If c t e) = "(If " ++ show c ++ " " ++ show t ++ " " ++ show e ++ ")"
+    show (Let x _) = "(Let " ++ show x ++ " f)"
+
+-- TODO: This needs improving, it's quite brittle at the moment!
+reduce :: Lam a -> Lam a
+reduce = fst . reduce'
+  where
+      reduce' :: Lam a -> (Lam a, Bool)
+      reduce' (App (Abs f) x)       = reduce' (f x)
+      reduce' (App (Var f) (Var x)) = (App (Var f) (Var x), True)
+      reduce' (App (Var f) x)       = let (x', stuck) = reduce' x in (App (Var f) x', stuck)
+      reduce' (App f x)             = let (f', stuck) = reduce' f in if stuck then (App f' x, True) else reduce' (App f' x)
+      reduce' (Abs f)               = (Abs f, False)
+      reduce' x                     = (x, True)
+
+generate :: Lam a -> Code a
+generate (Abs f) = [||\x -> $$(reduceAndGen (f (Var [||x||])))||]
+-- These have already been reduced, since we only expose `reduceAndGen`
+generate (App f x) = [||$$(generate f) $$(generate x)||]
+generate (Var x) = x
+generate (If c t e) = [||if $$(reduceAndGen c) then $$(reduceAndGen t) else $$(reduceAndGen e)||]
+generate (Let b i) = [||let x = $$(reduceAndGen b) in $$(reduceAndGen (i (Var [||x||])))||]
+
+reduceAndGen :: Lam a -> Code a
+reduceAndGen = generate . reduce


### PR DESCRIPTION
Added the `Lam` datatype, which is used to provide better code generation for the defunctionalised values. While it is used now, it will replace `Core.Defunc` in the backend in the next backward-incompatible release.