### PR TITLE
Improve `oneOf` and `noneOf`

### DIFF
--- a/parsley/ChangeLog.md
+++ b/parsley/ChangeLog.md
@@ -19,3 +19,7 @@
 ## 1.0.0.0 -- 2021-06-12
 
 * Factored all of the `Parsley.Internal` modules out into `parsley-core` package
+
+## 1.0.0.1 -- 2021-06-29
+
+* Improved implementation of `oneOf` and `noneOf` to use ranges and not exhaustive character search

--- a/parsley/parsley.cabal
+++ b/parsley/parsley.cabal
@@ -5,7 +5,7 @@ name:                parsley
 --                   | +------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             1.0.0.0
+version:             1.0.0.1
 synopsis:            A fast parser combinator library backed by Typed Template Haskell
 description:         Parsley is a staged selective parser combinator library, which means
                      it does not support monadic operations, and relies on Typed Template


### PR DESCRIPTION
The implementations of `oneOf` and `noneOf` can have their predicate more easily inlined, as well as the generated code shortened by collecting ranges in the input characters (which are commonly found as arguments to them). This means that generated code for `oneOf (['a' .. 'z'] ++ ['A' .. 'Z'] ++ ['0' .. '9'] ++ ['_'])` will look something like:

```hs
-- c from input stream
if ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9') || c == '_' then ...
```