### PR TITLE
Eliminate item check

### DIFF
--- a/parsley-core/ChangeLog.md
+++ b/parsley-core/ChangeLog.md
@@ -34,3 +34,9 @@
 ## 1.2.0.1 -- 2021-07-03
 
 * Added Jump-Elision optimisation to the code generator.
+
+## 1.3.0.0 -- 2021-07-03
+
+* Improved the `Lam` reduction algorithm
+* Preliminary support for `if true` reduction from `item` and `const True`
+* Introduced `_if` and `ap` in `Machine.Defunc`, removed `genDefunc1`

--- a/parsley-core/parsley-core.cabal
+++ b/parsley-core/parsley-core.cabal
@@ -5,7 +5,7 @@ name:                parsley-core
 --                   | +------- breaking internal API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             1.2.0.1
+version:             1.3.0.0
 synopsis:            A fast parser combinator library backed by Typed Template Haskell
 description:         This package contains the internals of the @parsley@ package.
                      .

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine.hs
@@ -20,7 +20,7 @@ import Data.Array.Unboxed                            (UArray)
 import Data.ByteString                               (ByteString)
 import Data.Dependent.Map                            (DMap)
 import Data.Text                                     (Text)
-import Parsley.Internal.Backend.Machine.Defunc       (Defunc(SAME), user)
+import Parsley.Internal.Backend.Machine.Defunc       (Defunc(SAME), user, userBool)
 import Parsley.Internal.Backend.Machine.Identifiers
 import Parsley.Internal.Backend.Machine.InputOps     (InputPrep(..), PositionOps)
 import Parsley.Internal.Backend.Machine.Instructions

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Defunc.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Defunc.hs
@@ -31,7 +31,7 @@ ap2 f@SAME (OFFSET o1) (OFFSET o2) = LAM (Lam.Var False (apSame f o1 o2))
     apSame :: forall o. Defunc (o -> o -> Bool) -> Code (Rep o) -> Code (Rep o) -> Code Bool
     apSame SAME = same (Proxy @o)
     apSame _    = undefined
-ap2 f x y = LAM (Lam.App (Lam.App (unliftDefunc f) (unliftDefunc x)) (unliftDefunc y))
+ap2 f x y = ap (ap f x) y
 
 _if :: Defunc Bool -> Code a -> Code a -> Code a
 _if c t e = normaliseGen (Lam.If (unliftDefunc c) (Lam.Var False t) (Lam.Var False e))

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Defunc.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Defunc.hs
@@ -19,27 +19,29 @@ data Defunc a where
 user :: Core.Defunc a -> Defunc a
 user = LAM . Core.lamTerm
 
+ap :: Defunc (a -> b) -> Defunc a -> Defunc b
+ap f x = LAM (Lam.App (unliftDefunc f) (unliftDefunc x))
+
 ap2 :: Defunc (a -> b -> c) -> Defunc a -> Defunc b -> Defunc c
 ap2 f@SAME (OFFSET o1) (OFFSET o2) = LAM (Lam.Var False (apSame f o1 o2))
   where
     apSame :: forall o. Defunc (o -> o -> Bool) -> Code (Rep o) -> Code (Rep o) -> Code Bool
     apSame SAME = same (Proxy @o)
     apSame _    = undefined
-ap2 f x y = LAM (Lam.App (Lam.App (seal f) (seal x)) (seal y))
-  where
-    seal :: Defunc a -> Lam a
-    seal (LAM x) = x
-    seal x        = Lam.Var False (genDefunc x)
+ap2 f x y = LAM (Lam.App (Lam.App (unliftDefunc f) (unliftDefunc x)) (unliftDefunc y))
+
+_if :: Defunc Bool -> Code a -> Code a -> Code a
+_if c t e = normaliseGen (Lam.If (unliftDefunc c) (Lam.Var False t) (Lam.Var False e))
+
+unliftDefunc :: Defunc a -> Lam a
+unliftDefunc (LAM x) = x
+unliftDefunc x       = Lam.Var False (genDefunc x)
 
 genDefunc :: Defunc a -> Code a
 genDefunc (LAM x)    = normaliseGen x
 genDefunc BOTTOM      = [||undefined||]
 genDefunc SAME        = error "Cannot materialise the same function in the regular way"
 genDefunc (OFFSET _)  = error "Cannot materialise an unboxed offset in the regular way"
-
-genDefunc1 :: Defunc (a -> b) -> Code a -> Code b
-genDefunc1 (LAM f) qx = normaliseGen (Lam.App f (Lam.Var True qx))
-genDefunc1 f qx       = [|| $$(genDefunc f) $$qx ||]
 
 pattern NormLam :: Lam a -> Defunc a
 pattern NormLam t <- LAM (normalise -> t)

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Defunc.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Defunc.hs
@@ -7,7 +7,7 @@ import Parsley.Internal.Backend.Machine.InputRep (Rep)
 import Parsley.Internal.Common.Utils             (Code)
 import Parsley.Internal.Core.Lam                 (Lam, normaliseGen, normalise)
 
-import qualified Parsley.Internal.Core.Defunc as Core (Defunc, lamTerm)
+import qualified Parsley.Internal.Core.Defunc as Core (Defunc, lamTerm, lamTermBool)
 import qualified Parsley.Internal.Core.Lam    as Lam  (Lam(..))
 
 data Defunc a where
@@ -18,6 +18,9 @@ data Defunc a where
 
 user :: Core.Defunc a -> Defunc a
 user = LAM . Core.lamTerm
+
+userBool :: Core.Defunc (a -> Bool) -> Defunc (a -> Bool)
+userBool = LAM . Core.lamTermBool
 
 ap :: Defunc (a -> b) -> Defunc a -> Defunc b
 ap f x = LAM (Lam.App (unliftDefunc f) (unliftDefunc x))

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Eval.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Eval.hs
@@ -12,7 +12,7 @@ import Data.Void                                      (Void)
 import Control.Monad                                  (forM, liftM2)
 import Control.Monad.Reader                           (ask, asks, local)
 import Control.Monad.ST                               (runST)
-import Parsley.Internal.Backend.Machine.Defunc        (Defunc(OFFSET), pattern FREEVAR, genDefunc, genDefunc1, ap2)
+import Parsley.Internal.Backend.Machine.Defunc        (Defunc(OFFSET), pattern FREEVAR, genDefunc, ap, ap2, _if)
 import Parsley.Internal.Backend.Machine.Identifiers   (MVar(..), ΦVar, ΣVar)
 import Parsley.Internal.Backend.Machine.InputOps      (InputDependant, PositionOps, LogOps, InputOps(InputOps))
 import Parsley.Internal.Backend.Machine.InputRep      (Rep)
@@ -96,10 +96,10 @@ evalSat p (Machine k) = do
      | hasChange -> maybeEmitCheck Nothing <$> local spendCoin k
      | otherwise -> trace "I have a piggy :)" $ local breakPiggy (maybeEmitCheck . Just <$> asks coins <*> local spendCoin k)
   where
-    maybeEmitCheck Nothing mk γ = sat (genDefunc1 p) mk (raise γ) γ
+    maybeEmitCheck Nothing mk γ = sat (ap p) mk (raise γ) γ
     maybeEmitCheck (Just n) mk γ =
-      --[|| let bad = $$(raise γ) in $$(emitLengthCheck n (sat (genDefunc1 p) mk [||bad||]) [||bad||] γ)||]
-      emitLengthCheck n (sat (genDefunc1 p) mk (raise γ)) (raise γ) γ
+      --[|| let bad = $$(raise γ) in $$(emitLengthCheck n (sat (ap p) mk [||bad||]) [||bad||] γ)||]
+      emitLengthCheck n (sat (ap p) mk (raise γ)) (raise γ) γ
 
 evalEmpt :: MachineMonad s o xs (Succ n) r a
 evalEmpt = return $! raise
@@ -128,11 +128,8 @@ evalChoices fs ks (Machine def) = liftM2 (\mdef mks γ -> let Op x xs = operands
   def
   (forM ks getMachine)
   where
-    go x (f:fs) (mk:mks) def γ = [||
-        if $$(genDefunc1 f (genDefunc x)) then $$(mk γ)
-        else $$(go x fs mks def γ)
-      ||]
-    go _ _ _ def γ = def γ
+    go x (f:fs) (mk:mks) def γ = _if (ap f x) (mk γ) (go x fs mks def γ)
+    go _ _      _        def γ = def γ
 
 evalIter :: RecBuilder o
          => MVar Void -> Machine s o '[] One Void a -> Machine s o (o : xs) n r a

--- a/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine.hs
+++ b/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine.hs
@@ -20,7 +20,7 @@ import Data.Array.Unboxed                            (UArray)
 import Data.ByteString                               (ByteString)
 import Data.Dependent.Map                            (DMap)
 import Data.Text                                     (Text)
-import Parsley.Internal.Backend.Machine.Defunc       (Defunc(SAME), user)
+import Parsley.Internal.Backend.Machine.Defunc       (Defunc(SAME), user, userBool)
 import Parsley.Internal.Backend.Machine.Identifiers
 import Parsley.Internal.Backend.Machine.InputOps     (InputPrep(..), PositionOps)
 import Parsley.Internal.Backend.Machine.InputRep     (Rep)

--- a/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Defunc.hs
+++ b/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Defunc.hs
@@ -5,7 +5,7 @@ import Parsley.Internal.Backend.Machine.InputOps (PositionOps(same))
 import Parsley.Internal.Common.Utils             (Code)
 import Parsley.Internal.Core.Lam                 (Lam, normaliseGen, normalise)
 
-import qualified Parsley.Internal.Core.Defunc as Core (Defunc, lamTerm)
+import qualified Parsley.Internal.Core.Defunc as Core (Defunc, lamTerm, lamTermBool)
 import qualified Parsley.Internal.Core.Lam    as Lam  (Lam(..))
 
 data Defunc a where
@@ -19,21 +19,23 @@ user = LAM . Core.lamTerm
 userBool :: Core.Defunc (a -> Bool) -> Defunc (a -> Bool)
 userBool = LAM . Core.lamTermBool
 
+ap :: Defunc (a -> b) -> Defunc a -> Defunc b
+ap f x = LAM (Lam.App (unliftDefunc f) (unliftDefunc x))
+
 ap2 :: Defunc (a -> b -> c) -> Defunc a -> Defunc b -> Defunc c
-ap2 f x y = LAM (Lam.App (Lam.App (seal f) (seal x)) (seal y))
-  where
-    seal :: Defunc a -> Lam a
-    seal (LAM x) = x
-    seal x       = Lam.Var False (genDefunc x)
+ap2 f x y = ap (ap f x) y
+
+_if :: Defunc Bool -> Code a -> Code a -> Code a
+_if c t e = normaliseGen (Lam.If (unliftDefunc c) (Lam.Var False t) (Lam.Var False e))
+
+unliftDefunc :: Defunc a -> Lam a
+unliftDefunc (LAM x) = x
+unliftDefunc x       = Lam.Var False (genDefunc x)
 
 genDefunc :: Defunc a -> Code a
 genDefunc (LAM x) = normaliseGen x
 genDefunc BOTTOM  = [||undefined||]
 genDefunc SAME    = same
-
-genDefunc1 :: Defunc (a -> b) -> Code a -> Code b
-genDefunc1 (LAM f) qx = normaliseGen (Lam.App f (Lam.Var True qx))
-genDefunc1 f qx       = [|| $$(genDefunc f) $$qx ||]
 
 pattern NormLam :: Lam a -> Defunc a
 pattern NormLam t <- LAM (normalise -> t)

--- a/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Defunc.hs
+++ b/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Defunc.hs
@@ -16,6 +16,9 @@ data Defunc a where
 user :: Core.Defunc a -> Defunc a
 user = LAM . Core.lamTerm
 
+userBool :: Core.Defunc (a -> Bool) -> Defunc (a -> Bool)
+userBool = LAM . Core.lamTermBool
+
 ap2 :: Defunc (a -> b -> c) -> Defunc a -> Defunc b -> Defunc c
 ap2 f x y = LAM (Lam.App (Lam.App (seal f) (seal x)) (seal y))
   where

--- a/parsley-core/src/ghc/Parsley/Internal/Core.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core.hs
@@ -14,6 +14,6 @@ module Parsley.Internal.Core (
     module Parsley.Internal.Core.InputTypes
   ) where
 
-import Parsley.Internal.Core.Defunc hiding (genDefunc, genDefunc1, genDefunc2, ap, unsafeBLACK, lamTerm, adaptLam)
+import Parsley.Internal.Core.Defunc hiding (genDefunc, genDefunc1, genDefunc2, ap, unsafeBLACK, lamTerm, lamTermBool, adaptLam)
 import Parsley.Internal.Core.InputTypes
 import Parsley.Internal.Core.Primitives (Parser, ParserOps)

--- a/parsley-core/src/ghc/Parsley/Internal/Core/Lam.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/Lam.hs
@@ -26,7 +26,7 @@ normalise x = reduce x
       | otherwise = App (reduceStep f) x
     reduceStep (If T x _) = x
     reduceStep (If F _ y) = y
-    reduceStep (If c x y) | normal c = If (reduceStep c) x y
+    reduceStep (If c x y) | not (normal c) = If (reduceStep c) x y
     reduceStep x = x
 
     normal :: Lam a -> Bool

--- a/parsley-core/src/ghc/Parsley/Internal/Core/Lam.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/Lam.hs
@@ -12,26 +12,24 @@ data Lam a where
     F   :: Lam Bool
 
 normalise :: Lam a -> Lam a
-normalise x = reduce x
+normalise x = if normal x then x else reduce x
   where
     reduce :: Lam a -> Lam a
-    reduce x
-      | normal x = x
-      | otherwise = reduce (reduceStep x)
-
-    reduceStep :: Lam a -> Lam a
-    reduceStep (App (Abs f) x) = f x
-    reduceStep (App f x)
-      | normal f = App f (reduceStep x)
-      | otherwise = App (reduceStep f) x
-    reduceStep (If T x _) = x
-    reduceStep (If F _ y) = y
-    reduceStep (If c x y) | not (normal c) = If (reduceStep c) x y
-    reduceStep x = x
+    reduce (App (Abs f) x) = case f x of
+      x | normal x -> x
+      x            -> reduce x
+    reduce (App f x) = case reduce f of
+      f@(Abs _) -> reduce (App f x)
+      f         -> App f x
+    reduce (If c x y) = case reduce c of
+      T -> x
+      F -> y
+      c -> If c x y
+    reduce x = x
 
     normal :: Lam a -> Bool
     normal (App (Abs _) _) = False
-    normal (App f x) = normal f && normal x
+    normal (App f _) = normal f
     normal (If T _ _) = False
     normal (If F _ _) = False
     normal (If x _ _) = normal x
@@ -39,10 +37,11 @@ normalise x = reduce x
 
 generate :: Lam a -> Code a
 generate (Abs f)    = [||\x -> $$(normaliseGen (f (Var True [||x||])))||]
--- These have already been reduced, since we only expose `normaliseGen`
-generate (App f x)  = [||$$(generate f) $$(generate x)||]
+-- f has already been reduced, since we only expose `normaliseGen`
+generate (App f x)  = [||$$(generate f) $$(normaliseGen x)||]
 generate (Var _ x)  = x
-generate (If c t e) = [||if $$(normaliseGen c) then $$(normaliseGen t) else $$(normaliseGen e)||]
+-- c has already been reduced, since we only expose `normaliseGen`
+generate (If c t e) = [||if $$(generate c) then $$(normaliseGen t) else $$(normaliseGen e)||]
 generate (Let b i)  = [||let x = $$(normaliseGen b) in $$(normaliseGen (i (Var True [||x||])))||]
 generate T          = [||True||]
 generate F          = [||False||]

--- a/parsley-core/src/ghc/Parsley/Internal/Core/Lam.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/Lam.hs
@@ -26,6 +26,7 @@ normalise x = reduce x
       | otherwise = App (reduceStep f) x
     reduceStep (If T x _) = x
     reduceStep (If F _ y) = y
+    reduceStep (If c x y) | normal c = If (reduceStep c) x y
     reduceStep x = x
 
     normal :: Lam a -> Bool
@@ -33,6 +34,7 @@ normalise x = reduce x
     normal (App f x) = normal f && normal x
     normal (If T _ _) = False
     normal (If F _ _) = False
+    normal (If x _ _) = normal x
     normal _ = True
 
 generate :: Lam a -> Code a


### PR DESCRIPTION
Leveraging the `If T` reduction rule in `Lam`, `const True` satisfy checks are eliminated in the generated code as they reduce to `T`. This support isn't entirely general yet, as that will require a `Typeable` constraint added to `LIFTED` which is a breaking parsley change.