### PR TITLE
Fix source-repository location

### DIFF
--- a/parsley-core/parsley-core.cabal
+++ b/parsley-core/parsley-core.cabal
@@ -132,4 +132,4 @@ library
 
 source-repository head
   type:                git
-  location:            https://github.com/j-mie6/HaskellParsley
+  location:            https://github.com/j-mie6/ParsleyHaskell

--- a/parsley/parsley.cabal
+++ b/parsley/parsley.cabal
@@ -84,7 +84,7 @@ library
 
 source-repository head
   type:                git
-  location:            https://github.com/j-mie6/HaskellParsley
+  location:            https://github.com/j-mie6/ParsleyHaskell
 
 common test-common
   build-depends:       base >=4.10 && <5,


### PR DESCRIPTION
Change https://github.com/j-mie6/HaskellParsley to https://github.com/j-mie6/ParsleyHaskell .