### PR TITLE
Static char info

### DIFF
--- a/parsley-core/ChangeLog.md
+++ b/parsley-core/ChangeLog.md
@@ -139,3 +139,25 @@ Fix for issue #27
 * Added `Typeable` constraint to `LIFTED`.
 * Removed `lamTermBool` and `userBool` from the API: `Typeable` subsumes them.
 * Added `RANGES` to the `Defunc` API.
+
+## 2.1.0.0 -- 2022-01-12
+
+* Added `RangeSet` datastructure.
+* Added `Pos` module for static manipulation of position information.
+* Added `CharPred` as a specialised defunctionalisation of `Char -> Bool` functions.
+* Moved `InputCharacteristic` to its own module.
+* Use `CharPred` for `Sat` and `Satisfy`.
+* Simplified the interface for `Ops.sat`.
+* Simplified `buildYesHandler` and allowed it to capture a statically annotated offset.
+* Introduced `buildIterYesHandler` which can capture static offet.
+* Changed types of `bindSameHandler` and `bindIterSame`.
+* Added `StaYesHandler` type to `Ops`.
+* Renamed `updatePos` to `updatePosQ`.
+* Added many methods for manipulating positions to `PosOps`.
+* Made `initPos` fully static.
+* Changed the type of `readChar`.
+* Hid some internals of `Input`.
+* Exposed some new methods for `Input`.
+* Added `INPUT` to 8.6+ backend for `Defunc`.
+* Added a `poke` method to `QueueLike`.
+* Added a `charPred` converter to `Defunc`.

--- a/parsley-core/benchmarks/BenchmarkUtils.hs
+++ b/parsley-core/benchmarks/BenchmarkUtils.hs
@@ -1,0 +1,7 @@
+module BenchmarkUtils where
+
+import Gauge.Main         (Benchmark, defaultMainWith)
+import Gauge.Main.Options (Config(displayMode), defaultConfig, DisplayMode(Condensed))
+
+condensedMain :: [Benchmark] -> IO ()
+condensedMain = defaultMainWith (defaultConfig {displayMode = Condensed})

--- a/parsley-core/benchmarks/RangeSetBench.hs
+++ b/parsley-core/benchmarks/RangeSetBench.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE StandaloneDeriving, DeriveAnyClass, DeriveGeneric, TypeApplications, BangPatterns #-}
+{-# LANGUAGE StandaloneDeriving, DeriveAnyClass, DeriveGeneric, TypeApplications, BangPatterns, TemplateHaskell #-}
 {-# OPTIONS_GHC -ddump-simpl -ddump-to-file #-}
 module Main where
 
@@ -80,21 +80,21 @@ rangeMemberBench =
                RangeSet.fromList xs4)) $ \t ->
     bgroup "RangeSet" [
       bgroup "member" [
-        bench "Pathological" $ nf (f (pi4_1 t)) ys1,
-        bench "4 way split" $ nf (f (pi4_2 t)) ys1,
-        bench "Small" $ nf (f (pi4_3 t)) ys2,
-        bench "alphaNum" $ nf (f (pi4_4 t)) ys3
+        bench "Pathological" $ nf (f ys1) (pi4_1 t),
+        bench "4 way split" $ nf (f ys1) (pi4_2 t),
+        bench "Small" $ nf (f ys2) (pi4_3 t),
+        bench "alphaNum" $ nf (f ys3) (pi4_4 t)
       ],
       bgroup "delete" [
-        bench "Pathological" $ nf (g (pi4_1 t)) ys1,
-        bench "4 way split" $ nf (g (pi4_2 t)) ys1,
-        bench "Small" $ nf (g (pi4_3 t)) ys2,
-        bench "alphaNum" $ nf (g (pi4_4 t)) ys3
+        bench "Pathological" $ nf (g ys1) (pi4_1 t),
+        bench "4 way split" $ nf (g ys1) (pi4_2 t),
+        bench "Small" $ nf (g ys2) (pi4_3 t),
+        bench "alphaNum" $ nf (g ys3) (pi4_4 t)
       ]
     ]
   where
-    f t = List.foldl' (\ !_ y -> RangeSet.member y t) False
-    g t = List.foldl' (\ !t y -> RangeSet.delete y t) t
+    f ys t = List.foldl' (\ !_ y -> RangeSet.member y t) False ys
+    g ys t = List.foldl' (\ !t y -> RangeSet.delete y t) t ys
 
 setMemberBench :: Benchmark
 setMemberBench =
@@ -103,22 +103,22 @@ setMemberBench =
                Set.fromList xs3,
                Set.fromList xs4)) $ \t ->
     bgroup "Set" [
-      bgroup "member" [
-        bench "Pathological" $ nf (f (pi4_1 t)) ys1,
-        bench "4 way split" $ nf (f (pi4_2 t)) ys1,
-        bench "Small" $ nf (f (pi4_3 t)) ys2,
-        bench "alphaNum" $ nf (f (pi4_4 t)) ys3
+            bgroup "member" [
+        bench "Pathological" $ nf (f ys1) (pi4_1 t),
+        bench "4 way split" $ nf (f ys1) (pi4_2 t),
+        bench "Small" $ nf (f ys2) (pi4_3 t),
+        bench "alphaNum" $ nf (f ys3) (pi4_4 t)
       ],
       bgroup "delete" [
-        bench "Pathological" $ nf (g (pi4_1 t)) ys1,
-        bench "4 way split" $ nf (g (pi4_2 t)) ys1,
-        bench "Small" $ nf (g (pi4_3 t)) ys2,
-        bench "alphaNum" $ nf (g (pi4_4 t)) ys3
+        bench "Pathological" $ nf (g ys1) (pi4_1 t),
+        bench "4 way split" $ nf (g ys1) (pi4_2 t),
+        bench "Small" $ nf (g ys2) (pi4_3 t),
+        bench "alphaNum" $ nf (g ys3) (pi4_4 t)
       ]
     ]
   where
-    f t = List.foldl' (\ !_ y -> Set.member y t) False
-    g t = List.foldl' (\ !t y -> Set.delete y t) t
+    f ys t = List.foldl' (\ !_ y -> Set.member y t) False ys
+    g ys t = List.foldl' (\ !t y -> Set.delete y t) t ys
 
 makeBench :: NFData a => (a -> String) -> [(String, a -> Benchmarkable)] -> a -> Benchmark
 makeBench caseName cases x = env (return x) (\x ->

--- a/parsley-core/benchmarks/RangeSetBench.hs
+++ b/parsley-core/benchmarks/RangeSetBench.hs
@@ -14,6 +14,8 @@ import Control.DeepSeq
 
 import GHC.Generics (Generic)
 
+import GHC.Word (Word32(..))
+
 import qualified Parsley.Internal.Common.RangeSet as RangeSet
 import qualified Data.Set as Set
 import qualified Data.List as List
@@ -23,6 +25,7 @@ deriving instance Generic a => Generic (RangeSet a)
 deriving instance Generic Int
 deriving instance Generic Word
 deriving instance Generic Char
+deriving instance Generic Word32
 
 main :: IO ()
 main = do
@@ -30,7 +33,9 @@ main = do
   condensedMain [
       --rangeFromList,
       --rangeMemberDeleteBench,
-      rangeUnionBench,
+      --rangeUnionBench,
+      rangeDiffBench,
+      rangeIntersectBench,
       setMemberDeleteBench,
       fromListBench xss
     ]
@@ -121,7 +126,7 @@ setMemberDeleteBench =
     f ys t = List.foldl' (\ !_ y -> Set.member y t) False ys
     g ys t = List.foldl' (\ !t y -> Set.delete y t) t ys
 
-zs1, zs2, zs3, zs4 :: RangeSet Word
+zs1, zs2, zs3, zs4 :: RangeSet Word32
 zs1 = RangeSet.fromRanges [(0, 50), (100, 150), (200, 250), (300, 350), (400, 450), (475, 500)]
 zs2 = RangeSet.fromRanges [(25, 75), (125, 175), (225, 275), (325, 375), (425, 475), (485, 500)]
 zs3 = RangeSet.fromRanges [(51, 99), (151, 199), (251, 299), (351, 399), (451, 474)]
@@ -134,6 +139,24 @@ rangeUnionBench =
       bench "overlaps" $ nf (RangeSet.union (pi4_1 t)) (pi4_2 t),
       bench "disjoint" $ nf (RangeSet.union (pi4_1 t)) (pi4_3 t),
       bench "messy" $ nf (RangeSet.union (pi4_1 t)) (pi4_4 t)
+  ]
+
+rangeDiffBench :: Benchmark
+rangeDiffBench =
+  env (return (zs1, zs2, zs3, zs4)) $ \t -> bgroup "difference" [
+      bench "same" $ nf (RangeSet.difference (pi4_1 t)) (pi4_1 t),
+      bench "overlaps" $ nf (RangeSet.difference (pi4_1 t)) (pi4_2 t),
+      bench "disjoint" $ nf (RangeSet.difference (pi4_1 t)) (pi4_3 t),
+      bench "messy" $ nf (RangeSet.difference (pi4_1 t)) (pi4_4 t)
+  ]
+
+rangeIntersectBench :: Benchmark
+rangeIntersectBench =
+  env (return (zs1, zs2, zs3, zs4)) $ \t -> bgroup "intersection" [
+      bench "same" $ nf (RangeSet.intersection (pi4_1 t)) (pi4_1 t),
+      bench "overlaps" $ nf (RangeSet.intersection (pi4_1 t)) (pi4_2 t),
+      bench "disjoint" $ nf (RangeSet.intersection (pi4_1 t)) (pi4_3 t),
+      bench "messy" $ nf (RangeSet.intersection (pi4_1 t)) (pi4_4 t)
   ]
 
 makeBench :: NFData a => (a -> String) -> [(String, a -> Benchmarkable)] -> a -> Benchmark

--- a/parsley-core/benchmarks/RangeSetBench.hs
+++ b/parsley-core/benchmarks/RangeSetBench.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE StandaloneDeriving, DeriveAnyClass, DeriveGeneric, TypeApplications, BangPatterns, TemplateHaskell #-}
+{-# LANGUAGE StandaloneDeriving, DeriveAnyClass, DeriveGeneric, BangPatterns #-}
 {-# OPTIONS_GHC -ddump-simpl -ddump-to-file #-}
 module Main where
 

--- a/parsley-core/benchmarks/RangeSetBench.hs
+++ b/parsley-core/benchmarks/RangeSetBench.hs
@@ -29,9 +29,9 @@ main = do
   xss <- forM [1..10] $ \n -> generate (vectorOf (n * 10) (chooseInt (0, n * 20)))
   condensedMain [
       rangeFromList,
-      fromListBench xss,
-      rangeMemberBench,
-      setMemberBench
+      rangeMemberDeleteBench,
+      setMemberDeleteBench,
+      fromListBench xss
     ]
 
 rangeFromList :: Benchmark
@@ -72,8 +72,8 @@ ys1 = [0..2048]
 ys2 = [0..27]
 ys3 = ['\x00'..'\xff']
 
-rangeMemberBench :: Benchmark
-rangeMemberBench =
+rangeMemberDeleteBench :: Benchmark
+rangeMemberDeleteBench =
   env (return (RangeSet.fromList xs1,
                RangeSet.fromList xs2,
                RangeSet.fromList xs3,
@@ -96,8 +96,8 @@ rangeMemberBench =
     f ys t = List.foldl' (\ !_ y -> RangeSet.member y t) False ys
     g ys t = List.foldl' (\ !t y -> RangeSet.delete y t) t ys
 
-setMemberBench :: Benchmark
-setMemberBench =
+setMemberDeleteBench :: Benchmark
+setMemberDeleteBench =
   env (return (Set.fromList xs1,
                Set.fromList xs2,
                Set.fromList xs3,

--- a/parsley-core/benchmarks/RangeSetBench.hs
+++ b/parsley-core/benchmarks/RangeSetBench.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE StandaloneDeriving, DeriveAnyClass, DeriveGeneric, TypeApplications, BangPatterns #-}
+{-# OPTIONS_GHC -ddump-simpl -ddump-to-file #-}
+module Main where
+
+import Gauge
+import BenchmarkUtils
+
+import Parsley.Internal.Common.RangeSet (RangeSet)
+import Data.Set (Set)
+import Test.QuickCheck
+
+import Control.Monad
+import Control.DeepSeq
+
+import GHC.Generics (Generic)
+
+import qualified Parsley.Internal.Common.RangeSet as RangeSet
+import qualified Data.Set as Set
+import qualified Data.List as List
+
+deriving instance (Generic a, NFData a) => NFData (RangeSet a)
+deriving instance Generic a => Generic (RangeSet a)
+deriving instance Generic Int
+deriving instance Generic Word
+deriving instance Generic Char
+
+main :: IO ()
+main = do
+  xss <- forM [1..10] $ \n -> generate (vectorOf (n * 10) (chooseInt (0, n * 20)))
+  condensedMain [
+      fromListBench xss,
+      rangeMemberBench,
+      setMemberBench
+    ]
+
+fromListBench :: [[Int]] -> Benchmark
+fromListBench xss =
+  bgroup "fromList" (map (makeBench (show . length)
+                                    [ ("Set", nf Set.fromList)
+                                    , ("RangeSet", nf RangeSet.fromList)
+                                    ]) xss)
+
+pi4_1 :: (a, b, c, d) -> a
+pi4_1 (x, _, _, _) = x
+
+pi4_2 :: (a, b, c, d) -> b
+pi4_2 (_, x, _, _) = x
+
+pi4_3 :: (a, b, c, d) -> c
+pi4_3 (_, _, x, _) = x
+
+pi4_4 :: (a, b, c, d) -> d
+pi4_4 (_, _, _, x) = x
+
+xs1, xs2, xs3 :: [Word]
+xs1 = [0,2..2048]
+xs2 = List.delete 1536 (List.delete 512 (List.delete 1024 [0..2048]))
+xs3 = [1, 2, 3, 5, 6, 7, 8, 11, 12, 13, 14, 16, 17, 18, 19, 20, 21, 22, 23, 25]
+xs4 = ['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9'] ++ ['_']
+
+ys1 = [0..2048]
+ys2 = [0..27]
+ys3 = ['\x00'..'\xff']
+
+rangeMemberBench :: Benchmark
+rangeMemberBench =
+  env (return (RangeSet.fromList xs1,
+               RangeSet.fromList xs2,
+               RangeSet.fromList xs3,
+               RangeSet.fromList xs4)) $ \t ->
+    bgroup "RangeSet.member" [
+      bench "Pathological" $ nf (f (pi4_1 t)) ys1,
+      bench "4 way split" $ nf (f (pi4_2 t)) ys1,
+      bench "Small" $ nf (f (pi4_3 t)) ys2,
+      bench "alphaNum" $ nf (f (pi4_4 t)) ys3
+    ]
+  where
+    f t = List.foldl' (\ !_ y -> RangeSet.member y t) False
+
+setMemberBench :: Benchmark
+setMemberBench =
+  env (return (Set.fromList xs1,
+               Set.fromList xs2,
+               Set.fromList xs3,
+               Set.fromList xs4)) $ \t ->
+    bgroup "Set.member" [
+      bench "Pathological" $ nf (f (pi4_1 t)) ys1,
+      bench "4 way split" $ nf (f (pi4_2 t)) ys1,
+      bench "Small" $ nf (f (pi4_3 t)) ys2,
+      bench "alphaNum" $ nf (f (pi4_4 t)) ys3
+    ]
+  where
+    f t = List.foldl' (\ !_ y -> Set.member y t) False
+
+makeBench :: NFData a => (a -> String) -> [(String, a -> Benchmarkable)] -> a -> Benchmark
+makeBench caseName cases x = env (return x) (\x ->
+  bgroup (caseName x) (map (\(name, gen) -> bench name $ gen x) cases))

--- a/parsley-core/benchmarks/RangeSetBench.hs
+++ b/parsley-core/benchmarks/RangeSetBench.hs
@@ -14,8 +14,6 @@ import Control.DeepSeq
 
 import GHC.Generics (Generic)
 
-import GHC.Word (Word32(..))
-
 import qualified Parsley.Internal.Common.RangeSet as RangeSet
 import qualified Data.Set as Set
 import qualified Data.List as List
@@ -25,15 +23,14 @@ deriving instance Generic a => Generic (RangeSet a)
 deriving instance Generic Int
 deriving instance Generic Word
 deriving instance Generic Char
-deriving instance Generic Word32
 
 main :: IO ()
 main = do
   xss <- forM [1..10] $ \n -> generate (vectorOf (n * 10) (chooseInt (0, n * 20)))
   condensedMain [
-      --rangeFromList,
-      --rangeMemberDeleteBench,
-      --rangeUnionBench,
+      rangeFromList,
+      rangeMemberDeleteBench,
+      rangeUnionBench,
       rangeDiffBench,
       rangeIntersectBench,
       setMemberDeleteBench,
@@ -126,7 +123,7 @@ setMemberDeleteBench =
     f ys t = List.foldl' (\ !_ y -> Set.member y t) False ys
     g ys t = List.foldl' (\ !t y -> Set.delete y t) t ys
 
-zs1, zs2, zs3, zs4 :: RangeSet Word32
+zs1, zs2, zs3, zs4 :: RangeSet Word
 zs1 = RangeSet.fromRanges [(0, 50), (100, 150), (200, 250), (300, 350), (400, 450), (475, 500)]
 zs2 = RangeSet.fromRanges [(25, 75), (125, 175), (225, 275), (325, 375), (425, 475), (485, 500)]
 zs3 = RangeSet.fromRanges [(51, 99), (151, 199), (251, 299), (351, 399), (451, 474)]

--- a/parsley-core/parsley-core.cabal
+++ b/parsley-core/parsley-core.cabal
@@ -97,6 +97,7 @@ library
 
                        Parsley.Internal.Backend.Machine.Types,
                        Parsley.Internal.Backend.Machine.Types.Coins,
+                       Parsley.Internal.Backend.Machine.Types.InputCharacteristic,
                        Parsley.Internal.Backend.Machine.Types.State
 
   if impl(ghc >= 8.10)
@@ -109,8 +110,8 @@ library
                        Parsley.Internal.Backend.Machine.Types.Input,
                        Parsley.Internal.Backend.Machine.Types.Statics,
 
-                       Parsley.Internal.Backend.Machine.Types.Input.Offset
-                       --Parsley.Internal.Backend.Machine.Types.Input.Pos
+                       Parsley.Internal.Backend.Machine.Types.Input.Offset,
+                       Parsley.Internal.Backend.Machine.Types.Input.Pos
 
   default-extensions:  BangPatterns
                        DataKinds

--- a/parsley-core/parsley-core.cabal
+++ b/parsley-core/parsley-core.cabal
@@ -5,7 +5,7 @@ name:                parsley-core
 --                   | +------- breaking internal API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             2.0.0.0
+version:             2.1.0.0
 synopsis:            A fast parser combinator library backed by Typed Template Haskell
 description:         This package contains the internals of the @parsley@ package.
                      .
@@ -57,6 +57,7 @@ library
 
                        Parsley.Internal.Core,
                        Parsley.Internal.Core.CombinatorAST,
+                       Parsley.Internal.Core.CharPred,
                        Parsley.Internal.Core.Defunc,
                        Parsley.Internal.Core.Identifiers,
                        Parsley.Internal.Core.InputTypes,

--- a/parsley-core/parsley-core.cabal
+++ b/parsley-core/parsley-core.cabal
@@ -45,6 +45,7 @@ library
                        Parsley.Internal.Common.Fresh,
                        Parsley.Internal.Common.Indexed,
                        Parsley.Internal.Common.QueueLike,
+                       Parsley.Internal.Common.RangeSet,
                        Parsley.Internal.Common.State,
                        Parsley.Internal.Common.Utils,
                        Parsley.Internal.Common.Vec,

--- a/parsley-core/parsley-core.cabal
+++ b/parsley-core/parsley-core.cabal
@@ -190,7 +190,7 @@ test-suite common-test
   type:                exitcode-stdio-1.0
   build-depends:       tasty-hunit, tasty-quickcheck
   main-is:             CommonTest.hs
-  other-modules:       CommonTest.Queue, CommonTest.RewindQueue
+  other-modules:       CommonTest.Queue, CommonTest.RewindQueue, CommonTest.RangeSet
 
 test-suite regression-test
   import:              test-common
@@ -198,6 +198,22 @@ test-suite regression-test
   build-depends:       tasty-hunit, tasty-quickcheck, containers
   main-is:             RegressionTest.hs
   other-modules:       Regression.Issue27
+
+common benchmark-common
+  build-depends:       base >=4.10 && <5,
+                       parsley-core,
+                       gauge,
+                       deepseq
+  hs-source-dirs:      benchmarks
+  other-modules:       BenchmarkUtils
+  default-language:    Haskell2010
+
+benchmark rangeset-bench
+  import:              benchmark-common
+  type:                exitcode-stdio-1.0
+  build-depends:       containers,
+                       QuickCheck
+  main-is:             RangeSetBench.hs
 
 source-repository head
   type:                git

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Defunc.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Defunc.hs
@@ -99,9 +99,9 @@ Generate the Haskell code that represents this defunctionalised value.
 @since 1.0.0.0
 -}
 genDefunc :: Defunc a -> Code a
-genDefunc (LAM x)    = normaliseGen x
-genDefunc BOTTOM      = [||undefined||]
-genDefunc (INPUT _)  = error "Cannot materialise an input in the regular way"
+genDefunc (LAM x) = normaliseGen x
+genDefunc BOTTOM  = [||undefined||]
+genDefunc INPUT{} = error "Cannot materialise an input in the regular way"
 
 {-|
 Pattern that normalises a `Lam` before returning it.

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Eval.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Eval.hs
@@ -215,6 +215,7 @@ evalPut σ a k = reader $ \ctx γ ->
   in writeΣ σ a x (run k (γ {operands = xs})) ctx
 
 -- TODO: FREEVAR is the wrong abstraction really...
+-- TODO: We could leverage the static information to make this require 0 computation!
 evalSelectPos :: PosSelector -> Machine s o (Int : xs) n r a -> MachineMonad s o xs n r a
 evalSelectPos Line (Machine k) = k <&> \m γ -> forcePos (input γ) $ \pos input' -> m (γ {operands = Op (FREEVAR (extractLine pos)) (operands γ), input = input'})
 evalSelectPos Col (Machine k) = k <&> \m γ -> forcePos (input γ) $ \pos input' -> m (γ {operands = Op (FREEVAR (extractCol pos)) (operands γ), input = input'})

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Eval.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Eval.hs
@@ -152,7 +152,7 @@ evalCatch (Machine k) h = freshUnique $ \u -> case h of
   Always gh (Machine h) ->
     liftM2 (\mk mh γ -> bindAlwaysHandler γ gh (buildHandler γ mh u) mk) k h
   Same gyes (Machine yes) gno (Machine no) ->
-    liftM3 (\mk myes mno γ -> bindSameHandler γ gyes (buildYesHandler γ myes u) gno (buildHandler γ mno u) mk) k yes no
+    liftM3 (\mk myes mno γ -> bindSameHandler γ gyes (buildYesHandler γ myes{- u-}) gno (buildHandler γ mno u) mk) k yes no
 
 evalTell :: Machine s o (o : xs) n r a -> MachineMonad s o xs n r a
 evalTell (Machine k) = k <&> \mk γ -> mk (γ {operands = Op (INPUT (input γ)) (operands γ)})
@@ -185,7 +185,7 @@ evalIter μ l h =
         Always gh (Machine h) ->
           liftM2 (\mh ctx γ -> bindIterAlways ctx μ l gh (buildHandler γ mh u1) (input γ) u2) h ask
         Same gyes (Machine yes) gno (Machine no) ->
-          liftM3 (\myes mno ctx γ -> bindIterSame ctx μ l gyes (buildYesHandler γ myes u1) gno (buildHandler γ mno u1) (input γ) u2) yes no ask
+          liftM3 (\myes mno ctx γ -> bindIterSame ctx μ l gyes (buildIterYesHandler γ myes u1) gno (buildHandler γ mno u1) (input γ) u2) yes no ask
 
 evalJoin :: ΦVar x -> MachineMonad s o (x : xs) n r a
 evalJoin φ = askΦ φ <&> resume

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/InputOps.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/InputOps.hs
@@ -157,7 +157,7 @@ instance InputPrep [Char] where
 
 instance InputPrep (UArray Int Char) where
   prepare qinput = [||
-      let UArray _ _ (I# size#) input# = $$qinput
+      let !(UArray _ _ (I# size#) input#) = $$qinput
           next i# = (# C# (indexWideCharArray# input# i#), i# +# 1# #)
       in (# next, \qi -> $$(intLess [||qi||] [||size#||]), 0# #)
     ||]

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Ops.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Ops.hs
@@ -239,6 +239,8 @@ both a captured and a current offset. Otherwise, is similar to `buildHandler`.
 
 @since 1.4.0.0
 -}
+--TODO: Degrading `Input` to `Input#` here is losing us information when binding handlers.
+--      This should return `Input -> Code (ST s (Maybe a))
 buildYesHandler :: Γ s o xs n r a
                 -> (Γ s o xs n r a -> Code (ST s (Maybe a)))
                 -> Word

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Ops.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Ops.hs
@@ -121,11 +121,11 @@ exist or does not match.
 @since 1.8.0.0
 -}
 sat :: (Defunc Char -> Defunc Bool)                        -- ^ Predicate to test the character with.
-    -> ((Code Char -> Input o -> aux -> Code b) -> Code b) -- ^ The source of the character
-    -> (Defunc Char -> Input o -> aux -> Code b)           -- ^ Code to execute on success.
+    -> Code Char                                           -- ^ The character to test against.
+    -> (Defunc Char -> Code b)                             -- ^ Code to execute on success.
     -> Code b                                              -- ^ Code to execute on failure.
     -> Code b
-sat p src good bad = src $ \c input' aux -> let v = FREEVAR c in _if (p v) (good v input' aux) bad
+sat p c good bad = let v = FREEVAR c in _if (p v) (good v) bad
 
 {-|
 Consumes the next character and adjusts the offset to match.
@@ -134,7 +134,7 @@ Consumes the next character and adjusts the offset to match.
 -}
 fetch :: (?ops :: InputOps (Rep o))
       => Input o -> (Code Char -> Input o -> Code b) -> Code b
-fetch input k = next (offset (off input)) $ \c offset' -> k c (consume c offset' input)
+fetch input k = next (offset (off input)) $ \c offset' -> k c (consume offset' input)
 
 {-|
 Emits a length check for a number of characters \(n\) in the most efficient

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/PosOps.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/PosOps.hs
@@ -29,16 +29,18 @@ import GHC.Prim                                    (plusWord#, and#, or#, word2I
 #endif
                                                    )
 
+data CharClass = Tab | Newline | Regular
+
 {-|
 Given a position and a character, returns the representation of the updated position.
 
 @since 1.8.0.0
 -}
-updatePos :: Maybe Char -> Code Pos -> Code Char -> Code Pos
-updatePos Nothing pos c = [||updatePos# $$pos $$c||]
-updatePos (Just '\t') pos _ = tab pos
-updatePos (Just '\n') pos _ = newline pos
-updatePos (Just _)    pos _ = other pos
+updatePos :: Maybe CharClass -> Code Pos -> Code Char -> Code Pos
+updatePos Nothing        pos c = [||updatePos# $$pos $$c||]
+updatePos (Just Tab)     pos _ = tab pos
+updatePos (Just Newline) pos _ = newline pos
+updatePos (Just Regular) pos _ = other pos
 
 {-|
 The initial position used by the parser. This is some representation of (1, 1).

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/PosOps.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/PosOps.hs
@@ -19,9 +19,9 @@ module Parsley.Internal.Backend.Machine.PosOps (CharClass(..), initPos, updatePo
 #define FULL_WIDTH_POSITIONS
 #endif
 
-import Data.Bits                                   ( (.&.)
+import Data.Bits                                   ( (.&.), (.|.)
 #ifndef FULL_WIDTH_POSITIONS
-                                                   , unsafeShiftL, (.|.)
+                                                   , unsafeShiftL
 #endif
                                                    )
 import Parsley.Internal.Backend.Machine.Types.Base (Pos)

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/PosOps.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/PosOps.hs
@@ -20,7 +20,7 @@ module Parsley.Internal.Backend.Machine.PosOps (module Parsley.Internal.Backend.
 
 import Parsley.Internal.Backend.Machine.Types.Base (Pos)
 import Parsley.Internal.Common                     (Code)
-import GHC.Exts                                    (Int(..))
+import GHC.Exts                                    (Int(..){-, Word(W#)-})
 import GHC.Prim                                    (plusWord#, and#, or#, word2Int#,
 #ifdef FULL_WIDTH_POSITIONS
                                                     minusWord#
@@ -34,8 +34,11 @@ Given a position and a character, returns the representation of the updated posi
 
 @since 1.8.0.0
 -}
-updatePos :: Code Pos -> Code Char -> Code Pos
-updatePos pos c = [||updatePos# $$pos $$c||]
+updatePos :: Maybe Char -> Code Pos -> Code Char -> Code Pos
+updatePos Nothing pos c = [||updatePos# $$pos $$c||]
+updatePos (Just '\t') pos _ = tab pos
+updatePos (Just '\n') pos _ = newline pos
+updatePos (Just _)    pos _ = other pos
 
 {-|
 The initial position used by the parser. This is some representation of (1, 1).
@@ -52,6 +55,12 @@ nearest 4th space boundary.
 @since 1.8.0.0
 -}
 updatePos# :: Pos -> Char -> Pos
+
+newline :: Code Pos -> Code Pos
+tab :: Code Pos -> Code Pos
+other :: Code Pos -> Code Pos
+
+--updatePosCode :: Code Pos -> Word -> Word -> Word -> Code Pos
 
 {-|
 Given the opaque representation of a position, extracts the line number out of it.
@@ -74,6 +83,12 @@ updatePos# pos '\n' = (pos `and#` 0xffffffff_00000000##) `plusWord#` 0x00000001_
 updatePos# pos '\t' = ((pos `plusWord#` 0x00000000_00000003##) `and#` 0xffffffff_fffffffc##) `or#` 0x00000000_00000001##
 updatePos# pos _    = pos `plusWord#` 0x00000000_00000001##
 
+newline qpos = [|| ($$qpos `and#` 0xffffffff_00000000##) `plusWord#` 0x00000001_00000001## ||]
+tab qpos = [|| (($$qpos `plusWord#` 0x00000000_00000003##) `and#` 0xffffffff_fffffffc##) `or#` 0x00000000_00000001## ||]
+other qpos = [|| $$qpos `plusWord#` 0x00000000_00000001## ||]
+
+--updatePosCode qpos (W# premask) (W# bitmask) (W# postmask) = qpos
+
 extractLine qpos = [||I# (word2Int# ($$qpos `uncheckedShiftRL#` 32#))||]
 extractCol qpos = [||I# (word2Int# ($$qpos `and#` 0x00000000_ffffffff##))||]
 
@@ -83,6 +98,12 @@ initPos = [|| (# 1##, 1## #) ||]
 updatePos# (# line, _ #)   '\n' = (# line `plusWord#` 1##, 1## #)
 updatePos# (# line, col #) '\t' = (# line, ((col `plusWord#` 3##) `and#` (0## `minusWord#` 4##)) `or#` 1## #) -- nearest tab boundary `c + (4 - (c - 1) % 4)`
 updatePos# (# line, col #) _    = (# line, col `plusWord#` 1## #)
+
+newline qpos = [|| case $$qpos of (# line, _ #) -> (# line `plusWord#` 1##, 1## #) ||]
+tab qpos = [|| case $$qpos of (# line, col #) -> (# line, ((col `plusWord#` 3##) `and#` (0## `minusWord#` 4##)) `or#` 1## #) ||]
+other qpos = [|| case $$qpos of (# line, col #) -> (# line, col `plusWord#` 1## #) ||]
+
+--updatePosCode qpos (W# premask) (W# bitmask) (W# postmask) = qpos
 
 extractLine qpos = [|| case $$qpos of (# line, _ #) -> I# (word2Int# line) ||]
 extractCol qpos = [|| case $$qpos of (# _, col #) -> I# (word2Int# col) ||]

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/PosOps.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/PosOps.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP, MagicHash, UnboxedTuples, NumericUnderscores #-}
+{-# OPTIONS_GHC -Wno-overflowed-literals #-}
 {-|
 Module      : Parsley.Internal.Backend.Machine.PosOps
 Description : Collection of platform dependent position operations
@@ -11,31 +12,40 @@ bits in a word, or if the @full-width-positions@ flag was set on the @parsley-co
 
 @since 1.8.0.0
 -}
-module Parsley.Internal.Backend.Machine.PosOps (CharClass(..), initPos, updatePos, updatePosQ, tabWidth, liftPos, extractLine, extractCol) where
+module Parsley.Internal.Backend.Machine.PosOps (CharClass(..), initPos, updatePos, toNextTab, updatePosQ, shiftLineAndSetColQ, shiftColQ, shiftAlignAndShiftColQ, tabWidth, liftPos, extractLine, extractCol) where
 
 #include "MachDeps.h"
 #if WORD_SIZE_IN_BITS < 64
 #define FULL_WIDTH_POSITIONS
 #endif
 
+import Data.Bits                                   ( (.&.)
+#ifndef FULL_WIDTH_POSITIONS
+                                                   , unsafeShiftL, (.|.)
+#endif
+                                                   )
 import Parsley.Internal.Backend.Machine.Types.Base (Pos)
 import Parsley.Internal.Common                     (Code)
 import GHC.Exts                                    (Int(..), Word(W#))
-import GHC.Prim                                    (plusWord#, and#, or#, word2Int#,
+import GHC.Prim                                    ( plusWord#, and#, or#, word2Int#
 #ifdef FULL_WIDTH_POSITIONS
-                                                    minusWord#
+                                                   , minusWord#
 #else
-                                                    uncheckedShiftRL#, uncheckedShiftL#
+                                                   , uncheckedShiftRL#
 #endif
                                                    )
 
-data CharClass = Tab | Newline | Regular
+data CharClass = Tab | Newline | Regular | NonNewline
 
-updatePos :: Maybe CharClass -> Code Char -> (Word, Word) -> Either (Code Pos) (Word, Word)
-updatePos Nothing        c pos         = Left [||updatePos# $$(liftPos pos) $$c||]
-updatePos (Just Tab)     _ (line, col) = Right (line, col + (tabWidth - ((col - 1) `mod` tabWidth)))
-updatePos (Just Newline) _ (line, _)   = Right (line + 1, 1)
-updatePos (Just Regular) _ (line, col) = Right (line, col + 1)
+toNextTab :: Word -> Word
+toNextTab x = (x + tabWidth - 1) .&. negate tabWidth .|. 1
+
+updatePos :: Maybe CharClass -> Code Char -> Word -> Word -> Either (Code Pos) (Word, Word)
+updatePos Nothing           c line col = Left [||updatePos# $$(liftPos line col) $$c||]
+updatePos (Just Tab)        _ line col = Right (line, toNextTab col)
+updatePos (Just Newline)    _ line _   = Right (line + 1, 1)
+updatePos (Just Regular)    _ line col = Right (line, col + 1)
+updatePos (Just NonNewline) c line col = Left [||updatePosNonNewline# $$(liftPos line col) $$c||]
 
 {-|
 Given a position and a character, returns the representation of the updated position.
@@ -43,10 +53,11 @@ Given a position and a character, returns the representation of the updated posi
 @since 2.1.0.0
 -}
 updatePosQ :: Maybe CharClass -> Code Char -> Code Pos -> Code Pos
-updatePosQ Nothing        c pos = [||updatePos# $$pos $$c||]
-updatePosQ (Just Tab)     _ pos = tabQ pos
-updatePosQ (Just Newline) _ pos = newlineQ pos
-updatePosQ (Just Regular) _ pos = regularQ pos
+updatePosQ Nothing           c pos = [||updatePos# $$pos $$c||]
+updatePosQ (Just Tab)        _ pos = shiftAlignAndShiftColQ 0 0 pos
+updatePosQ (Just Newline)    _ pos = shiftLineAndSetColQ 1 1 pos
+updatePosQ (Just Regular)    _ pos = shiftColQ 1 pos
+updatePosQ (Just NonNewline) c pos = [||updatePosNonNewline# $$pos $$c ||]
 
 {-|
 The initial position used by the parser. This is some representation of (1, 1).
@@ -68,9 +79,12 @@ nearest 4th space boundary.
 -}
 updatePos# :: Pos -> Char -> Pos
 
-newlineQ :: Code Pos -> Code Pos
-tabQ :: Code Pos -> Code Pos
-regularQ :: Code Pos -> Code Pos
+{-# INLINEABLE updatePosNonNewline# #-}
+updatePosNonNewline# :: Pos -> Char -> Pos
+
+shiftColQ :: Word -> Code Pos -> Code Pos
+shiftLineAndSetColQ :: Word -> Word -> Code Pos -> Code Pos
+shiftAlignAndShiftColQ :: Word -> Word -> Code Pos -> Code Pos
 
 --updatePosCode :: Code Pos -> Word -> Word -> Word -> Code Pos
 
@@ -88,38 +102,54 @@ Given the opaque representation of a position, extracts the column number out of
 -}
 extractCol :: Code Pos -> Code Int
 
-liftPos :: (Word, Word) -> Code Pos
+liftPos :: Word -> Word -> Code Pos
 
 #ifndef FULL_WIDTH_POSITIONS
 
+-- This is refered to directly in generated code, leave optimised primitives
 updatePos# pos '\n' = (pos `and#` 0xffffffff_00000000##) `plusWord#` 0x00000001_00000001##
 updatePos# pos '\t' = ((pos `plusWord#` 0x00000000_00000003##) `and#` 0xffffffff_fffffffc##) `or#` 0x00000000_00000001##
 updatePos# pos _    = pos `plusWord#` 0x00000000_00000001##
 
-newlineQ qpos = [|| ($$qpos `and#` 0xffffffff_00000000##) `plusWord#` 0x00000001_00000001## ||]
-tabQ qpos = [|| (($$qpos `plusWord#` 0x00000000_00000003##) `and#` 0xffffffff_fffffffc##) `or#` 0x00000000_00000001## ||]
-regularQ qpos = [|| $$qpos `plusWord#` 0x00000000_00000001## ||]
+updatePosNonNewline# pos '\t' = ((pos `plusWord#` 0x00000000_00000003##) `and#` 0xffffffff_fffffffc##) `or#` 0x00000000_00000001##
+updatePosNonNewline# pos _    = pos `plusWord#` 0x00000000_00000001##
 
---updatePosCode qpos (W# premask) (W# bitmask) (W# postmask) = qpos
+shiftLineAndSetColQ n col qpos = [|| ($$qpos `and#` 0xffffffff_00000000##) `plusWord#` $$(liftPos n col) ||]
+shiftColQ (W# n) qpos = [|| $$qpos `plusWord#` n ||]
+shiftAlignAndShiftColQ firstBy thenBy qpos =
+  let !(W# pre) = firstBy + 3 -- offset first, then add 3 to overshoot
+      !(W# mask) = -4         -- constant fold this into raw literal
+      !(W# post) = thenBy + 1 -- add the offset of tab boundary from power of two, then remaining positions
+  in if thenBy == 0 then [|| (($$qpos `plusWord#` pre) `and#` mask) `or#` 0x00000000_00000001## ||] -- because tab widths are multiples of two
+     else                [|| (($$qpos `plusWord#` pre) `and#` mask) `plusWord#` post ||]
 
 extractLine qpos = [||I# (word2Int# ($$qpos `uncheckedShiftRL#` 32#))||]
 extractCol qpos = [||I# (word2Int# ($$qpos `and#` 0x00000000_ffffffff##))||]
 
-liftPos (W# line, W# col) = let p = (line `uncheckedShiftL#` 32#) `or#` col in [||p||]
+liftPos line col = let !(W# p) = (line `unsafeShiftL` 32) .|. col in [||p||]
 
 #else
+-- This is refered to directly in generated code, leave optimised primitives
 updatePos# (# line, _ #)   '\n' = (# line `plusWord#` 1##, 1## #)
 updatePos# (# line, col #) '\t' = (# line, ((col `plusWord#` 3##) `and#` (0## `minusWord#` 4##)) `or#` 1## #) -- nearest tab boundary `c + (4 - (c - 1) % 4)`
 updatePos# (# line, col #) _    = (# line, col `plusWord#` 1## #)
 
-newlineQ qpos = [|| case $$qpos of (# line, _ #) -> (# line `plusWord#` 1##, 1## #) ||]
-tabQ qpos = [|| case $$qpos of (# line, col #) -> (# line, ((col `plusWord#` 3##) `and#` (0## `minusWord#` 4##)) `or#` 1## #) ||]
-regularQ qpos = [|| case $$qpos of (# line, col #) -> (# line, col `plusWord#` 1## #) ||]
+updatePosNonNewline# (# line, col #) '\t' = (# line, ((col `plusWord#` 3##) `and#` (0## `minusWord#` 4##)) `or#` 1## #) -- nearest tab boundary `c + (4 - (c - 1) % 4)`
+updatePosNonNewline# (# line, col #) _    = (# line, col `plusWord#` 1## #)
 
---updatePosCode qpos (W# premask) (W# bitmask) (W# postmask) = qpos
+shiftLineAndSetColQ (W# n) (W# col) qpos = [|| case $$qpos of (# line, _ #) -> (# line `plusWord#` n, col #) ||]
+shiftColQ (W# n) qpos = [|| case $$qpos of (# line, col #) -> (# line, col `plusWord#` n #) ||]
+shiftAlignAndShiftColQ firstBy thenBy qpos =
+  let !(W# pre) = firstBy + 3 -- offset first, then add 3 to overshoot
+      !(W# mask) = -4         -- constant fold this into raw literal
+      !(W# post) = thenBy + 1 -- add the offset of tab boundary from power of two, then remaining positions
+  in [|| case $$qpos of
+           (# line, col #) -> (# line,
+             $$(if thenBy == 0 then [|| ((col `plusWord#` pre) `and#` mask) `or#` 1## ||] -- because tab widths are multiples of two
+                else                [|| ((col `plusWord#` pre) `and#` mask) `plusWord#` post ||]) #) ||]
 
 extractLine qpos = [|| case $$qpos of (# line, _ #) -> I# (word2Int# line) ||]
 extractCol qpos = [|| case $$qpos of (# _, col #) -> I# (word2Int# col) ||]
 
-liftPos (W# line, W# col) = [||(# line, col #)||]
+liftPos (W# line) (W# col) = [||(# line, col #)||]
 #endif

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Base.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Base.hs
@@ -36,8 +36,10 @@ The type of positions within a parser. This may or may not be packed into a sing
 -}
 #ifndef FULL_WIDTH_POSITIONS
 type Pos = Word#
+type BoxedPos = Word
 #else
 type Pos = (# Word#, Word# #)
+type BoxedPos = (Word, Word)
 #endif
 
 {-|

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Base.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Base.hs
@@ -36,10 +36,8 @@ The type of positions within a parser. This may or may not be packed into a sing
 -}
 #ifndef FULL_WIDTH_POSITIONS
 type Pos = Word#
-type BoxedPos = Word
 #else
 type Pos = (# Word#, Word# #)
-type BoxedPos = (Word, Word)
 #endif
 
 {-|

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Context.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Context.hs
@@ -434,7 +434,7 @@ Reads a character from the context's retrieval queue if one exists.
 If not, reads a character from another given source (and adds it to the
 rewind buffer).
 
-@since 1.5.0.0
+@since 2.1.0.0
 -}
 readChar :: Ctx s o a                                                             -- ^ The original context.
          -> CharPred                                                              -- ^ The predicate that this character will be tested against

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Context.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Context.hs
@@ -88,9 +88,9 @@ may form part of the generated code.
 data Ctx s o a = Ctx { μs         :: !(DMap MVar (QSubroutine s o a))              -- ^ Map of subroutine bindings.
                      , φs         :: !(DMap ΦVar (QJoin s o a))                    -- ^ Map of join point bindings.
                      , σs         :: !(DMap ΣVar (Reg s))                          -- ^ Map of available registers.
-                     , debugLevel :: !Int                                          -- ^ Approximate depth of debug combinator.
-                     , coins      :: !Int                                          -- ^ Number of tokens free to consume without length check.
-                     , offsetUniq :: !Word                                         -- ^ Next unique offset identifier.
+                     , debugLevel :: {-# UNPACK #-} !Int                           -- ^ Approximate depth of debug combinator.
+                     , coins      :: {-# UNPACK #-} !Int                           -- ^ Number of tokens free to consume without length check.
+                     , offsetUniq :: {-# UNPACK #-} !Word                          -- ^ Next unique offset identifier.
                      , piggies    :: !(Queue Coins)                                -- ^ Queue of future length check credit.
                      , knownChars :: !(RewindQueue (Code Char, CharPred, Input o)) -- ^ Characters that can be reclaimed on backtrack.
                      }

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Context.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Context.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE DeriveAnyClass,
              MagicHash,
              DerivingStrategies,
-             UnboxedTuples #-}
+             UnboxedTuples,
+             PatternSynonyms #-}
 {-|
 Module      : Parsley.Internal.Backend.Machine.Types.Context
 Description : Fully static context required to generate a parser
@@ -69,7 +70,8 @@ import Parsley.Internal.Backend.Machine.Types.Coins    (Coins, willConsume, canR
 import Parsley.Internal.Backend.Machine.Types.Dynamics (DynFunc, DynSubroutine)
 import Parsley.Internal.Backend.Machine.Types.Input    (Input)
 import Parsley.Internal.Backend.Machine.Types.Statics  (QSubroutine(..), StaFunc, StaSubroutine, StaCont)
-import Parsley.Internal.Common                         (Queue, enqueue, dequeue, Code, RewindQueue)
+import Parsley.Internal.Common                         (Queue, enqueue, dequeue, poke, Code, RewindQueue)
+import Parsley.Internal.Core.CharPred                  (CharPred, pattern Item, andPred)
 
 import qualified Data.Dependent.Map                           as DMap  ((!), insert, empty, lookup)
 import qualified Parsley.Internal.Common.QueueLike            as Queue (empty, null)
@@ -83,14 +85,14 @@ may form part of the generated code.
 
 @since 1.0.0.0
 -}
-data Ctx s o a = Ctx { μs         :: DMap MVar (QSubroutine s o a)     -- ^ Map of subroutine bindings.
-                     , φs         :: DMap ΦVar (QJoin s o a)           -- ^ Map of join point bindings.
-                     , σs         :: DMap ΣVar (Reg s)                 -- ^ Map of available registers.
-                     , debugLevel :: Int                               -- ^ Approximate depth of debug combinator.
-                     , coins      :: Int                               -- ^ Number of tokens free to consume without length check.
-                     , offsetUniq :: Word                              -- ^ Next unique offset identifier.
-                     , piggies    :: Queue Coins                       -- ^ Queue of future length check credit.
-                     , knownChars :: RewindQueue (Code Char, Input o) -- ^ Characters that can be reclaimed on backtrack.
+data Ctx s o a = Ctx { μs         :: !(DMap MVar (QSubroutine s o a))              -- ^ Map of subroutine bindings.
+                     , φs         :: !(DMap ΦVar (QJoin s o a))                    -- ^ Map of join point bindings.
+                     , σs         :: !(DMap ΣVar (Reg s))                          -- ^ Map of available registers.
+                     , debugLevel :: !Int                                          -- ^ Approximate depth of debug combinator.
+                     , coins      :: !Int                                          -- ^ Number of tokens free to consume without length check.
+                     , offsetUniq :: !Word                                         -- ^ Next unique offset identifier.
+                     , piggies    :: !(Queue Coins)                                -- ^ Queue of future length check credit.
+                     , knownChars :: !(RewindQueue (Code Char, CharPred, Input o)) -- ^ Characters that can be reclaimed on backtrack.
                      }
 
 {-|
@@ -425,7 +427,7 @@ can be retrieved later.
 @since 1.5.0.0
 -}
 addChar :: Code Char -> Input o -> Ctx s o a -> Ctx s o a
-addChar c o ctx = ctx { knownChars = enqueue (c, o) (knownChars ctx) }
+addChar c o ctx = ctx { knownChars = enqueue (c, Item, o) (knownChars ctx) }
 
 {-|
 Reads a character from the context's retrieval queue if one exists.
@@ -434,16 +436,23 @@ rewind buffer).
 
 @since 1.5.0.0
 -}
-readChar :: Ctx s o a                                     -- ^ The original context.
-         -> ((Code Char -> Input o -> Code b) -> Code b)  -- ^ The fallback source of input.
-         -> (Code Char -> Input o -> Ctx s o a -> Code b) -- ^ The continuation that needs the read characters and updated context.
+readChar :: Ctx s o a                                                             -- ^ The original context.
+         -> CharPred                                                              -- ^ The predicate that this character will be tested against
+         -> ((Code Char -> Input o -> Code b) -> Code b)                          -- ^ The fallback source of input.
+         -> (Code Char -> CharPred -> CharPred -> Input o -> Ctx s o a -> Code b) -- ^ The continuation that needs the read characters and updated context.
          -> Code b
-readChar ctx fallback k
+readChar ctx pred fallback k
   | reclaimable = unsafeReadChar ctx k
   | otherwise   = fallback $ \c o -> unsafeReadChar (addChar c o ctx) k
   where
     reclaimable = not (Queue.null (knownChars ctx))
-    unsafeReadChar ctx k = let ((c, o), q) = dequeue (knownChars ctx) in k c o (ctx { knownChars = q })
+    unsafeReadChar ctx k = let -- combine the old information with the new information, refining the predicate
+                               -- This works for notFollowedBy at the /moment/ because the predicate does not cross the handler boundary...
+                               -- Perhaps any that cross handler boundaries should be complemented if that ever happens.
+                               updateChar (c, p, o) = (c, andPred p pred, o)
+                               ((_, pOld, _), q) = poke updateChar (knownChars ctx)
+                               ((c, p, o), q') = dequeue q
+                           in k c pOld p o (ctx { knownChars = q' })
 
 -- Exceptions
 newtype MissingDependency = MissingDependency IMVar deriving anyclass Exception

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input.hs
@@ -15,7 +15,7 @@ module Parsley.Internal.Backend.Machine.Types.Input (module Parsley.Internal.Bac
 
 import Parsley.Internal.Backend.Machine.InputRep                  (Rep)
 import Parsley.Internal.Backend.Machine.Types.Input.Offset        (Offset(offset), mkOffset, moveOne, moveN)
-import Parsley.Internal.Backend.Machine.Types.Input.Pos           (StaPos, DynPos, toDynPos, fromDynPos, force, update)
+import Parsley.Internal.Backend.Machine.Types.Input.Pos           (StaPos, DynPos, BoxedPos, toDynPos, fromDynPos, fromStaPos, force, update)
 import Parsley.Internal.Backend.Machine.Types.InputCharacteristic (InputCharacteristic(..))
 import Parsley.Internal.Common.Utils                              (Code)
 import Parsley.Internal.Core.CharPred                             (CharPred)
@@ -41,8 +41,8 @@ data Input# o = Input# {
     pos#  :: !DynPos
   }
 
-mkInput :: Code (Rep o) -> DynPos -> Input o
-mkInput off = toInput 0 . Input# off
+mkInput :: Code (Rep o) -> BoxedPos -> Input o
+mkInput off = Input (mkOffset off 0) . fromStaPos
 
 consume :: Code (Rep o) -> Input o -> Input o
 consume offset' input = input {

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input.hs
@@ -15,7 +15,7 @@ module Parsley.Internal.Backend.Machine.Types.Input (module Parsley.Internal.Bac
 
 import Parsley.Internal.Backend.Machine.InputRep                  (Rep)
 import Parsley.Internal.Backend.Machine.Types.Input.Offset        (Offset(offset), mkOffset, moveOne, moveN)
-import Parsley.Internal.Backend.Machine.Types.Input.Pos           (StaPos, DynPos, BoxedPos, toDynPos, fromDynPos, fromStaPos, force, update)
+import Parsley.Internal.Backend.Machine.Types.Input.Pos           (StaPos, DynPos, toDynPos, fromDynPos, fromStaPos, force, update)
 import Parsley.Internal.Backend.Machine.Types.InputCharacteristic (InputCharacteristic(..))
 import Parsley.Internal.Common.Utils                              (Code)
 import Parsley.Internal.Core.CharPred                             (CharPred)
@@ -41,7 +41,7 @@ data Input# o = Input# {
     pos#  :: !DynPos
   }
 
-mkInput :: Code (Rep o) -> BoxedPos -> Input o
+mkInput :: Code (Rep o) -> (Word, Word) -> Input o
 mkInput off = Input (mkOffset off 0) . fromStaPos
 
 consume :: Code (Rep o) -> Input o -> Input o

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input.hs
@@ -19,6 +19,8 @@ import Parsley.Internal.Backend.Machine.Types.Input.Pos           (StaPos, DynPo
 import Parsley.Internal.Backend.Machine.Types.InputCharacteristic (InputCharacteristic(..))
 import Parsley.Internal.Common.Utils                              (Code)
 import Parsley.Internal.Core.CharPred                             (CharPred)
+import Parsley.Internal.Core.CombinatorAST                        (PosSelector)
+
 {-|
 Packages known static information about offsets (via `Offset`) with static information about positions
 (currently unavailable).
@@ -49,8 +51,8 @@ consume offset' input = input {
     off = moveOne (off input) offset'
   }
 
-forcePos :: Input o -> (DynPos -> Input o -> Code r) -> Code r
-forcePos input k = force (pos input) (\dp sp -> k dp (input { pos = sp }))
+forcePos :: Input o -> PosSelector -> (Code Int -> Input o -> Code r) -> Code r
+forcePos input sel k = force (pos input) sel (\dp sp -> k dp (input { pos = sp }))
 
 updatePos :: Input o -> Code Char -> CharPred -> Input o
 updatePos input c p = input { pos = update (pos input) c p }

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input/Pos.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input/Pos.hs
@@ -1,59 +1,89 @@
-{-# LANGUAGE RecordWildCards, UnboxedTuples, PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards, UnboxedTuples, PatternSynonyms, DerivingStrategies #-}
 module Parsley.Internal.Backend.Machine.Types.Input.Pos (
-    StaPos, DynPos,
-    fromDynPos, toDynPos,
+    StaPos, DynPos, BoxedPos,
+    fromDynPos, toDynPos, fromStaPos,
     force, update
   ) where
 
 import Parsley.Internal.Common.Utils (Code)
 import Parsley.Internal.Core.CharPred (CharPred, pattern Specific, apply)
-import Parsley.Internal.Backend.Machine.PosOps (CharClass(..))
+import Parsley.Internal.Backend.Machine.PosOps (CharClass(..), liftPos, unbox)
 
 import qualified Parsley.Internal.Backend.Machine.PosOps as Ops (updatePos)
-import qualified Parsley.Internal.Backend.Machine.Types.Base as Base (Pos)
+import qualified Parsley.Internal.Backend.Machine.Types.Base as Base (Pos, BoxedPos)
 
 type DynPos = Code Base.Pos
+type BoxedPos = Base.BoxedPos
+
+data Pos = Static Base.Pos | Dynamic DynPos
 
 data StaPos = StaPos {
-    -- TODO: What about the case where dynPos == initialPos? We could mark this statically
-    dynPos :: !DynPos,
+    dynPos :: !Pos,
+    alignment :: !Alignment,
     contributing :: ![StaChar]
   }
+
+data Alignment = Unknown | Unaligned Int | Aligned deriving stock Show
 
 data StaChar = StaChar {
     char :: !(Code Char),
     predicate :: !CharPred
   }
 
-fromDynPos :: DynPos -> StaPos
-fromDynPos pos = StaPos { dynPos = pos, contributing = [] }
+mkStaPos :: Pos -> StaPos
+mkStaPos pos = StaPos { dynPos = pos, alignment = Unknown, contributing = [] }
 
--- TODO: This should preserve any alignment information we have statically on the forward
+fromDynPos :: DynPos -> StaPos
+fromDynPos = mkStaPos . Dynamic
+
+fromStaPos :: BoxedPos -> StaPos
+fromStaPos p = mkStaPos (Static (unbox p))
+
+fromPos :: Pos -> DynPos
+fromPos (Static p) = liftPos p
+fromPos (Dynamic p) = p
+
 force :: StaPos -> (DynPos -> StaPos -> Code r) -> Code r
 force p k
-  | null (contributing p) = k (dynPos p) p
+  | null (contributing p) = k (fromPos (dynPos p)) p
   | otherwise = [||
         let pos = $$(toDynPos p)
-        in $$(k [||pos||] (fromDynPos [||pos||]))
+        in $$(k [||pos||] (StaPos {
+            dynPos = Dynamic [||pos||],
+            alignment = alignment p,
+            contributing = []
+          }))
       ||]
 
 update :: StaPos -> Code Char -> CharPred -> StaPos
-update pos c p = pos { contributing = StaChar c p : contributing pos }
+update pos c p = pos { contributing = StaChar c p : contributing pos
+                     ,  alignment = updateAlignment (knownChar p) (alignment pos)
+                     }
+  where
+    updateAlignment Nothing        _             = Unknown
+    updateAlignment (Just Regular) Aligned       = Unaligned 1
+    updateAlignment (Just Regular) (Unaligned n)
+      | n == 3                                   = Aligned
+      | otherwise                                = Unaligned (n + 1)
+    updateAlignment (Just Regular) Unknown       = Unknown
+    updateAlignment _              _             = Aligned
 
 -- TODO: we want to collapse into a single update statically!
+-- TODO: take into account initial alignment
 toDynPos :: StaPos -> DynPos
-toDynPos StaPos{..} = foldr f dynPos contributing
+toDynPos StaPos{..} = foldr f (fromPos dynPos) contributing
   where
     f StaChar{..} p = Ops.updatePos (knownChar predicate) p char
 
-    knownChar (Specific '\t')         = Just Tab
-    knownChar (Specific '\n')         = Just Newline
-    knownChar p | not (apply p '\t'),
-                  not (apply p '\n')  = Just Regular
-    knownChar _                       = Nothing
+knownChar :: CharPred -> Maybe CharClass
+knownChar (Specific '\t')         = Just Tab
+knownChar (Specific '\n')         = Just Newline
+knownChar p | not (apply p '\t'),
+              not (apply p '\n')  = Just Regular
+knownChar _                       = Nothing
 
 instance Show StaPos where
-  show (StaPos{..}) = "StaPos { dynPos = ?, contributing = " ++ show contributing ++ "}"
+  show StaPos{..} = "StaPos { dynPos = ?, alignment = " ++ show alignment ++ ", contributing = " ++ show contributing ++ "}"
 
 instance Show StaChar where
-  show (StaChar{..}) = "StaChar { char = ?, predicate = " ++ show predicate ++ "}"
+  show StaChar{..} = "StaChar { char = ?, predicate = " ++ show predicate ++ "}"

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input/Pos.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input/Pos.hs
@@ -2,11 +2,12 @@
 module Parsley.Internal.Backend.Machine.Types.Input.Pos (
     StaPos, DynPos,
     fromDynPos, toDynPos,
-    contribute, force, update
+    force, update
   ) where
 
 import Parsley.Internal.Common.Utils (Code)
-import Parsley.Internal.Core.CharPred (CharPred, pattern Specific, andPred)
+import Parsley.Internal.Core.CharPred (CharPred, pattern Specific, apply)
+import Parsley.Internal.Backend.Machine.PosOps (CharClass(..))
 
 import qualified Parsley.Internal.Backend.Machine.PosOps as Ops (updatePos)
 import qualified Parsley.Internal.Backend.Machine.Types.Base as Base (Pos)
@@ -15,20 +16,17 @@ type DynPos = Code Base.Pos
 
 data StaPos = StaPos {
     -- TODO: What about the case where dynPos == initialPos? We could mark this statically
-    dynPos :: DynPos,
-    contributing :: [StaChar]
+    dynPos :: !DynPos,
+    contributing :: ![StaChar]
   }
 
 data StaChar = StaChar {
-    char :: Code Char,
-    predicate :: Maybe CharPred
+    char :: !(Code Char),
+    predicate :: !CharPred
   }
 
 fromDynPos :: DynPos -> StaPos
 fromDynPos pos = StaPos { dynPos = pos, contributing = [] }
-
-contribute :: StaPos -> Code Char -> StaPos
-contribute pos c = pos { contributing = StaChar c Nothing : contributing pos }
 
 -- TODO: This should preserve any alignment information we have statically on the forward
 force :: StaPos -> (DynPos -> StaPos -> Code r) -> Code r
@@ -39,16 +37,23 @@ force p k
         in $$(k [||pos||] (fromDynPos [||pos||]))
       ||]
 
-update :: StaPos -> CharPred -> StaPos
-update pos p =
-  let sc@StaChar{..} : cs = contributing pos
-  in pos { contributing = sc { predicate = Just (maybe p (andPred p) predicate) } : cs }
+update :: StaPos -> Code Char -> CharPred -> StaPos
+update pos c p = pos { contributing = StaChar c p : contributing pos }
 
--- TODO: The knownChar thing is see specific, and besides, we want to collapse into a single update statically!
+-- TODO: we want to collapse into a single update statically!
 toDynPos :: StaPos -> DynPos
 toDynPos StaPos{..} = foldr f dynPos contributing
   where
-    f StaChar{..} p = Ops.updatePos (predicate >>= knownChar) p char
+    f StaChar{..} p = Ops.updatePos (knownChar predicate) p char
 
-    knownChar (Specific c) = Just c
-    knownChar _            = Nothing
+    knownChar (Specific '\t')         = Just Tab
+    knownChar (Specific '\n')         = Just Newline
+    knownChar p | not (apply p '\t'),
+                  not (apply p '\n')  = Just Regular
+    knownChar _                       = Nothing
+
+instance Show StaPos where
+  show (StaPos{..}) = "StaPos { dynPos = ?, contributing = " ++ show contributing ++ "}"
+
+instance Show StaChar where
+  show (StaChar{..}) = "StaChar { char = ?, predicate = " ++ show predicate ++ "}"

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input/Pos.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input/Pos.hs
@@ -1,1 +1,46 @@
-module Parsley.Internal.Backend.Machine.Types.Input.Pos ({-module Parsley.Internal.Backend.Machine.Types.Input.Pos-}) where
+{-# LANGUAGE RecordWildCards #-}
+module Parsley.Internal.Backend.Machine.Types.Input.Pos (module Parsley.Internal.Backend.Machine.Types.Input.Pos) where
+
+import Parsley.Internal.Common.Utils (Code)
+import Parsley.Internal.Core.CharPred (CharPred(Specific), andPred)
+
+import qualified Parsley.Internal.Backend.Machine.PosOps as Ops (updatePos)
+import qualified Parsley.Internal.Backend.Machine.Types.Base as Base (Pos)
+
+data Pos = Pos {
+    dynPos :: Code Base.Pos,
+    contributing :: [StaChar]
+  }
+
+data StaChar = StaChar {
+    char :: Code Char,
+    predicate :: Maybe CharPred
+  }
+
+fromDynPos :: Code Base.Pos -> Pos
+fromDynPos pos = Pos { dynPos = pos, contributing = [] }
+
+contribute :: Pos -> Code Char -> Pos
+contribute pos c = pos { contributing = StaChar c Nothing : contributing pos }
+
+-- TODO: This should preserve any alignment information we have statically on the forward
+force :: Pos -> (Code Base.Pos -> Pos -> Code r) -> Code r
+force p k
+  | null (contributing p) = k (dynPos p) p
+  | otherwise = [||
+        let pos = $$(toDynPos p)
+        in $$(k [||pos||] (fromDynPos [||pos||]))
+      ||]
+
+update :: Pos -> CharPred -> Pos
+update pos p =
+  let sc@StaChar{..} : cs = contributing pos
+  in pos { contributing = sc { predicate = Just (maybe p (andPred p) predicate) } : cs }
+
+toDynPos :: Pos -> Code Base.Pos
+toDynPos Pos{..} = foldr f dynPos contributing
+  where
+    f StaChar{..} p = Ops.updatePos (predicate >>= knownChar) p char
+
+    knownChar (Specific c) = Just c
+    knownChar _            = Nothing

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input/Pos.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input/Pos.hs
@@ -5,6 +5,7 @@ module Parsley.Internal.Backend.Machine.Types.Input.Pos (
     force, update
   ) where
 
+import Data.Bits ((.|.), (.&.))
 import Parsley.Internal.Common.Utils (Code)
 import Parsley.Internal.Core.CharPred (CharPred, pattern Specific, apply)
 import Parsley.Internal.Backend.Machine.PosOps (CharClass(..), liftPos)
@@ -22,7 +23,10 @@ data StaPos = StaPos {
     contributing :: ![StaChar]
   }
 
-data Alignment = Unknown | Unaligned Word | Aligned deriving stock Show
+data Alignment = Unknown | Unaligned {-# UNPACK #-} !Word deriving stock Show
+
+pattern Aligned :: Alignment
+pattern Aligned = Unaligned 0
 
 data StaChar = StaChar {
     char :: !(Code Char),
@@ -33,11 +37,7 @@ mkStaPos :: Pos -> StaPos
 mkStaPos pos = StaPos { dynPos = pos, alignment = alignment pos, contributing = [] }
   where
     alignment Dynamic{} = Unknown
-    alignment (Static (_, col))
-      | trailingBehindBoundary == 0 = Aligned
-      | otherwise                   = Unaligned trailingBehindBoundary
-      where
-        trailingBehindBoundary = col - 1 `mod` Ops.tabWidth
+    alignment (Static (_, col)) = Unaligned (col - 1 `mod` Ops.tabWidth)
 
 fromDynPos :: DynPos -> StaPos
 fromDynPos = mkStaPos . Dynamic
@@ -70,26 +70,95 @@ update pos c p = pos { contributing = StaChar c p : contributing pos }
 
 updateAlignment :: [StaChar] -> Alignment -> Alignment
 updateAlignment cs a = foldr (updateAlignment' . knownChar . predicate) a cs
-  where
-    updateAlignment' :: Maybe CharClass -> Alignment -> Alignment
-    updateAlignment' Nothing        _             = Unknown
-    updateAlignment' (Just Regular) Aligned       = Unaligned 1
-    updateAlignment' (Just Regular) (Unaligned n)
-      | n == Ops.tabWidth - 1                     = Aligned
-      | otherwise                                 = Unaligned (n + 1)
-    updateAlignment' (Just Regular) Unknown       = Unknown
-    updateAlignment' _              _             = Aligned
+
+updateAlignment' :: Maybe CharClass -> Alignment -> Alignment
+updateAlignment' Nothing        _             = Unknown
+updateAlignment' (Just Regular) Aligned       = Unaligned 1
+updateAlignment' (Just Regular) (Unaligned n)
+  | n == Ops.tabWidth - 1                     = Aligned
+  | otherwise                                 = Unaligned (n + 1)
+updateAlignment' (Just Regular) Unknown       = Unknown
+updateAlignment' _              _             = Aligned
 
 -- TODO: we want to collapse into a single update statically!
 -- TODO: take into account initial alignment
+{-
+1) Use a similar strategy from Scala Parsley: use this to create an updater up to the next unknown character
+   BUT: use the initial alignment to guide the first updater
+2) Build a list of updaters to apply: sequences of static updates and dynamic ones
+3) Apply these updaters to the static or dynamic position - this involves translating an updater
+   to optimised form.
+4) profit
+-}
 collapse :: StaPos -> Pos
 collapse StaPos{..} = foldr f dynPos contributing
   where
-    f StaChar{..} = let charClass = knownChar predicate in throughEither (Ops.updatePos charClass char) (Ops.updatePosQ charClass char)
+    f StaChar{..} =
+      let charClass = knownChar predicate
+      in throughEither (Ops.updatePos charClass char)
+                       (Ops.updatePosQ charClass char)
 
     throughEither :: ((Word, Word) -> Either DynPos (Word, Word)) -> (DynPos -> DynPos) -> Pos -> Pos
     throughEither sta _ (Static p)  = either Dynamic Static (sta p)
     throughEither _ dyn (Dynamic p) = Dynamic (dyn p)
+
+data ColUpdater = Set {-# UNPACK #-} !Word
+                | Offset {-# UNPACK #-} !Word
+                | OffsetAlignOffset {-# UNPACK #-} !Word {-# UNPACK #-} !Word
+
+updateTab :: ColUpdater -> ColUpdater
+updateTab (Set n) = Set ((n + Ops.tabWidth - 1) .&. Ops.tabWidth .|. 1)
+updateTab (Offset n) = OffsetAlignOffset n 0
+updateTab (OffsetAlignOffset firstBy thenBy) = OffsetAlignOffset firstBy (toNextTabFromKnownAlignment thenBy)
+
+toNextTabFromKnownAlignment :: Word -> Word
+toNextTabFromKnownAlignment x = (x .|. Ops.tabWidth - 1) + 1
+
+updateRegular :: ColUpdater -> ColUpdater
+updateRegular (Set n) = Set (n + 1)
+updateRegular (Offset n) = Set (n + 1)
+updateRegular (OffsetAlignOffset firstBy thenBy) = OffsetAlignOffset firstBy (thenBy + 1)
+
+data Updater = Updater {
+    lineUpdate :: {-# UNPACK #-} !Word,
+    colUpdate :: !ColUpdater
+  }
+
+pattern NoUpdate :: Updater
+pattern NoUpdate = Updater { lineUpdate = 0, colUpdate = Offset 0 }
+
+pattern ColOnly :: ColUpdater -> Updater
+pattern ColOnly colUpdate = Updater 0 colUpdate
+
+{-| Takes the initial alignment and contributing characters and
+    return the list of updaters (in order from left-to-right)
+    that must be applied to update the position properly -}
+-- TODO: A line-update removes all previous static updaters: dynamic ones need to remain, in case
+--       they update the line. But these can actually be converted to a no-op in the non-line case!
+buildUpdaters :: Alignment -> [StaChar] -> [Maybe Updater]
+buildUpdaters alignment = applyAlignment alignment . reverse . uncurry combine . foldr f (NoUpdate, [])
+  where
+    -- The known initial alignment can affect the /first/ updater
+    applyAlignment :: Alignment -> [Maybe Updater] -> [Maybe Updater]
+    applyAlignment (Unaligned n) (Just (ColOnly (OffsetAlignOffset firstBy thenBy)) : updaters) =
+      -- We know what the current alignment boundary is, so can eliminate the Align
+      let pre = n + firstBy
+          nextTabIn = toNextTabFromKnownAlignment pre
+      in Just (ColOnly (Offset (nextTabIn + thenBy))) : updaters
+    applyAlignment _ updaters = updaters
+
+    combine :: Updater -> [Maybe Updater] -> [Maybe Updater]
+    combine NoUpdate updaters = updaters
+    combine updater updaters = Just updater : updaters
+
+    f :: StaChar -> (Updater, [Maybe Updater]) -> (Updater, [Maybe Updater])
+    f StaChar{..} (updater, updaters) =
+      let charClass = knownChar predicate
+      in case charClass of
+        Nothing -> (NoUpdate, Nothing : combine updater updaters)
+        Just Tab -> (updater { colUpdate = updateTab (colUpdate updater) }, updaters)
+        Just Newline -> (updater { lineUpdate = lineUpdate updater + 1, colUpdate = Set 0 }, updaters)
+        Just Regular -> (updater { colUpdate = updateRegular (colUpdate updater) }, updaters)
 
 toDynPos :: StaPos -> DynPos
 toDynPos = fromPos . collapse

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input/Pos.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input/Pos.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards, UnboxedTuples #-}
+{-# LANGUAGE RecordWildCards, UnboxedTuples, PatternSynonyms #-}
 module Parsley.Internal.Backend.Machine.Types.Input.Pos (
     StaPos, DynPos,
     fromDynPos, toDynPos,
@@ -6,7 +6,7 @@ module Parsley.Internal.Backend.Machine.Types.Input.Pos (
   ) where
 
 import Parsley.Internal.Common.Utils (Code)
-import Parsley.Internal.Core.CharPred (CharPred(Specific), andPred)
+import Parsley.Internal.Core.CharPred (CharPred, pattern Specific, andPred)
 
 import qualified Parsley.Internal.Backend.Machine.PosOps as Ops (updatePos)
 import qualified Parsley.Internal.Backend.Machine.Types.Base as Base (Pos)

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input/Pos.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Input/Pos.hs
@@ -1,5 +1,9 @@
-{-# LANGUAGE RecordWildCards #-}
-module Parsley.Internal.Backend.Machine.Types.Input.Pos (module Parsley.Internal.Backend.Machine.Types.Input.Pos) where
+{-# LANGUAGE RecordWildCards, UnboxedTuples #-}
+module Parsley.Internal.Backend.Machine.Types.Input.Pos (
+    StaPos, DynPos,
+    fromDynPos, toDynPos,
+    contribute, force, update
+  ) where
 
 import Parsley.Internal.Common.Utils (Code)
 import Parsley.Internal.Core.CharPred (CharPred(Specific), andPred)
@@ -7,8 +11,11 @@ import Parsley.Internal.Core.CharPred (CharPred(Specific), andPred)
 import qualified Parsley.Internal.Backend.Machine.PosOps as Ops (updatePos)
 import qualified Parsley.Internal.Backend.Machine.Types.Base as Base (Pos)
 
-data Pos = Pos {
-    dynPos :: Code Base.Pos,
+type DynPos = Code Base.Pos
+
+data StaPos = StaPos {
+    -- TODO: What about the case where dynPos == initialPos? We could mark this statically
+    dynPos :: DynPos,
     contributing :: [StaChar]
   }
 
@@ -17,14 +24,14 @@ data StaChar = StaChar {
     predicate :: Maybe CharPred
   }
 
-fromDynPos :: Code Base.Pos -> Pos
-fromDynPos pos = Pos { dynPos = pos, contributing = [] }
+fromDynPos :: DynPos -> StaPos
+fromDynPos pos = StaPos { dynPos = pos, contributing = [] }
 
-contribute :: Pos -> Code Char -> Pos
+contribute :: StaPos -> Code Char -> StaPos
 contribute pos c = pos { contributing = StaChar c Nothing : contributing pos }
 
 -- TODO: This should preserve any alignment information we have statically on the forward
-force :: Pos -> (Code Base.Pos -> Pos -> Code r) -> Code r
+force :: StaPos -> (DynPos -> StaPos -> Code r) -> Code r
 force p k
   | null (contributing p) = k (dynPos p) p
   | otherwise = [||
@@ -32,13 +39,14 @@ force p k
         in $$(k [||pos||] (fromDynPos [||pos||]))
       ||]
 
-update :: Pos -> CharPred -> Pos
+update :: StaPos -> CharPred -> StaPos
 update pos p =
   let sc@StaChar{..} : cs = contributing pos
   in pos { contributing = sc { predicate = Just (maybe p (andPred p) predicate) } : cs }
 
-toDynPos :: Pos -> Code Base.Pos
-toDynPos Pos{..} = foldr f dynPos contributing
+-- TODO: The knownChar thing is see specific, and besides, we want to collapse into a single update statically!
+toDynPos :: StaPos -> DynPos
+toDynPos StaPos{..} = foldr f dynPos contributing
   where
     f StaChar{..} p = Ops.updatePos (predicate >>= knownChar) p char
 

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/State.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/State.hs
@@ -41,8 +41,8 @@ of a parser in their variously statically augmented forms.
 
 @since 1.4.0.0
 -}
-data Γ s o xs n r a = Γ { operands :: OpStack xs                        -- ^ The current values available for applicative application.
-                        , retCont  :: StaCont s o a r                   -- ^ The current return continuation when this parser is finished.
-                        , input    :: Input o                           -- ^ The current offset into the input of the parser.
-                        , handlers :: Vec n (AugmentedStaHandler s o a) -- ^ The failure handlers that are used to process failure during a parser.
+data Γ s o xs n r a = Γ { operands :: !(OpStack xs)                        -- ^ The current values available for applicative application.
+                        , retCont  :: !(StaCont s o a r)                   -- ^ The current return continuation when this parser is finished.
+                        , input    :: !(Input o)                           -- ^ The current offset into the input of the parser.
+                        , handlers :: !(Vec n (AugmentedStaHandler s o a)) -- ^ The failure handlers that are used to process failure during a parser.
                         }

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Statics.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types/Statics.hs
@@ -46,15 +46,16 @@ module Parsley.Internal.Backend.Machine.Types.Statics (
     staSubroutine#, meta,
   ) where
 
-import Control.Monad.ST                                    (ST)
-import Data.STRef                                          (STRef)
-import Data.Kind                                           (Type)
-import Data.Maybe                                          (fromMaybe)
-import Parsley.Internal.Backend.Machine.LetBindings        (Regs(..), Metadata, newMeta, InputCharacteristic(..))
-import Parsley.Internal.Backend.Machine.Types.Dynamics     (DynCont, DynHandler, DynFunc)
-import Parsley.Internal.Backend.Machine.Types.Input        (Input(..), Input#(..), fromInput)
-import Parsley.Internal.Backend.Machine.Types.Input.Offset (Offset, same)
-import Parsley.Internal.Common.Utils                       (Code)
+import Control.Monad.ST                                           (ST)
+import Data.STRef                                                 (STRef)
+import Data.Kind                                                  (Type)
+import Data.Maybe                                                 (fromMaybe)
+import Parsley.Internal.Backend.Machine.LetBindings               (Regs(..), Metadata, newMeta)
+import Parsley.Internal.Backend.Machine.Types.Dynamics            (DynCont, DynHandler, DynFunc)
+import Parsley.Internal.Backend.Machine.Types.Input               (Input(..), Input#(..), fromInput)
+import Parsley.Internal.Backend.Machine.Types.Input.Offset        (Offset, same)
+import Parsley.Internal.Backend.Machine.Types.InputCharacteristic (InputCharacteristic(..))
+import Parsley.Internal.Common.Utils                              (Code)
 
 -- Handlers
 {-|

--- a/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Defunc.hs
+++ b/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Defunc.hs
@@ -11,6 +11,7 @@ import qualified Parsley.Internal.Core.Lam    as Lam  (Lam(..))
 data Defunc a where
   LAM     :: Lam a -> Defunc a
   BOTTOM  :: Defunc a
+  INPUT   :: Code o -> (Code Int, Code Int) -> Defunc o
   SAME    :: PositionOps o => Defunc (o -> o -> Bool)
 
 user :: Core.Defunc a -> Defunc a
@@ -32,6 +33,7 @@ unliftDefunc x       = Lam.Var False (genDefunc x)
 genDefunc :: Defunc a -> Code a
 genDefunc (LAM x) = normaliseGen x
 genDefunc BOTTOM  = [||undefined||]
+genDefunc INPUT{} = error "Cannot materialise an input in the regular way"
 genDefunc SAME    = same
 
 pattern NormLam :: Lam a -> Defunc a
@@ -45,4 +47,5 @@ pattern FREEVAR v <- NormLam (Lam.Var True v)
 instance Show (Defunc a) where
   show (LAM x) = show x
   show SAME = "same"
+  show INPUT{} = "input"
   show BOTTOM = "[[irrelevant]]"

--- a/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Defunc.hs
+++ b/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Defunc.hs
@@ -21,7 +21,8 @@ ap :: Defunc (a -> b) -> Defunc a -> Defunc b
 ap f x = LAM (Lam.App (unliftDefunc f) (unliftDefunc x))
 
 ap2 :: Defunc (a -> b -> c) -> Defunc a -> Defunc b -> Defunc c
-ap2 f x = ap (ap f x)
+ap2 SAME (INPUT o1 _) (INPUT o2 _) = LAM (Lam.Var False [|| $$same $$o1 $$o2 ||])
+ap2 f x y = ap (ap f x) y
 
 _if :: Defunc Bool -> Code a -> Code a -> Code a
 _if c t e = normaliseGen (Lam.If (unliftDefunc c) (Lam.Var False t) (Lam.Var False e))

--- a/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Eval.hs
+++ b/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Eval.hs
@@ -11,7 +11,7 @@ import Data.Void                                      (Void)
 import Control.Monad                                  (forM, liftM2)
 import Control.Monad.Reader                           (ask, asks, local)
 import Control.Monad.ST                               (runST)
-import Parsley.Internal.Backend.Machine.Defunc        (Defunc(LAM, SAME), pattern FREEVAR, genDefunc, ap, ap2, _if)
+import Parsley.Internal.Backend.Machine.Defunc        (Defunc(LAM, SAME, INPUT), pattern FREEVAR, genDefunc, ap, ap2, _if)
 import Parsley.Internal.Backend.Machine.Identifiers   (MVar(..), ΦVar, ΣVar)
 import Parsley.Internal.Backend.Machine.InputOps      (InputDependant(..), PositionOps, BoxOps, LogOps, InputOps(InputOps))
 import Parsley.Internal.Backend.Machine.Instructions  (Instr(..), MetaInstr(..), Access(..), PosSelector(..))
@@ -122,10 +122,10 @@ evalHandler (Instructions.Same _ yes _ no) =
         Machine (evalChoices [LAM (Abs id)] [Machine (evalPop yes)] no)))))))
 
 evalTell :: Machine s o (o : xs) n r a -> MachineMonad s o xs n r a
-evalTell (Machine k) = k <&> \mk γ -> mk (γ {operands = Op (FREEVAR (input γ)) (operands γ)})
+evalTell (Machine k) = k <&> \mk γ -> mk (γ {operands = Op (INPUT (input γ) (pos γ)) (operands γ)})
 
 evalSeek :: Machine s o xs n r a -> MachineMonad s o (o : xs) n r a
-evalSeek (Machine k) = k <&> \mk γ -> let Op input xs = operands γ in mk (γ {operands = xs, input = genDefunc input})
+evalSeek (Machine k) = k <&> \mk γ -> let Op (INPUT input pos) xs = operands γ in mk (γ {operands = xs, input = input, pos = pos})
 
 evalCase :: Machine s o (x : xs) n r a -> Machine s o (y : xs) n r a -> MachineMonad s o (Either x y : xs) n r a
 evalCase (Machine p) (Machine q) = liftM2 (\mp mq γ ->

--- a/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Eval.hs
+++ b/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Eval.hs
@@ -21,6 +21,7 @@ import Parsley.Internal.Backend.Machine.Ops
 import Parsley.Internal.Backend.Machine.Types.Coins   (willConsume)
 import Parsley.Internal.Backend.Machine.Types.State
 import Parsley.Internal.Common                        (Fix4, cata4, One, Code, Vec(..), Nat(..))
+import Parsley.Internal.Core                          (CharPred)
 import Parsley.Internal.Trace                         (Trace(trace))
 import System.Console.Pretty                          (color, Color(Green))
 
@@ -91,7 +92,7 @@ evalPop (Machine k) = k <&> \m γ -> m (γ {operands = let Op _ xs = operands γ
 evalLift2 :: Defunc (x -> y -> z) -> Machine s o (z : xs) n r a -> MachineMonad s o (y : x : xs) n r a
 evalLift2 f (Machine k) = k <&> \m γ -> m (γ {operands = let Op y (Op x xs) = operands γ in Op (ap2 f x y) xs})
 
-evalSat :: (?ops :: InputOps o, PositionOps o, BoxOps o, HandlerOps o, Trace) => Defunc (Char -> Bool) -> Machine s o (Char : xs) (Succ n) r a -> MachineMonad s o xs (Succ n) r a
+evalSat :: (?ops :: InputOps o, PositionOps o, BoxOps o, HandlerOps o, Trace) => CharPred -> Machine s o (Char : xs) (Succ n) r a -> MachineMonad s o xs (Succ n) r a
 evalSat p (Machine k) = do
   bankrupt <- asks isBankrupt
   hasChange <- asks hasCoin
@@ -99,9 +100,9 @@ evalSat p (Machine k) = do
      | hasChange -> maybeEmitCheck Nothing <$> local spendCoin k
      | otherwise -> trace "I have a piggy :)" $ local breakPiggy (asks ((maybeEmitCheck . Just) . coins) <*> local spendCoin k)
   where
-    maybeEmitCheck Nothing mk γ = sat (ap p) mk (raise γ) γ
+    maybeEmitCheck Nothing mk γ = sat p mk (raise γ) γ
     maybeEmitCheck (Just n) mk γ =
-      [|| let bad = $$(raise γ) in $$(emitLengthCheck n (sat (ap p) mk [||bad||]) [||bad||] γ)||]
+      [|| let bad = $$(raise γ) in $$(emitLengthCheck n (sat p mk [||bad||]) [||bad||] γ)||]
 
 evalEmpt :: (BoxOps o, HandlerOps o) => MachineMonad s o xs (Succ n) r a
 evalEmpt = return $! raise

--- a/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Ops.hs
+++ b/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Ops.hs
@@ -19,7 +19,7 @@ import Data.STRef                                    (writeSTRef, readSTRef, new
 import Data.Text                                     (Text)
 import Data.Void                                     (Void)
 import Debug.Trace                                   (trace)
-import Parsley.Internal.Backend.Machine.Defunc       (Defunc(LAM), pattern FREEVAR, genDefunc, ap, _if)
+import Parsley.Internal.Backend.Machine.Defunc       (Defunc(LAM, INPUT), pattern FREEVAR, genDefunc, ap, _if)
 import Parsley.Internal.Backend.Machine.Identifiers  (MVar, ΦVar, ΣVar)
 import Parsley.Internal.Backend.Machine.InputOps     (PositionOps(..), BoxOps(..), LogOps(..), InputOps, next, more)
 import Parsley.Internal.Backend.Machine.InputRep     (Unboxed, OffWith, UnpackedLazyByteString, Stream{-, representationTypes-})
@@ -66,6 +66,7 @@ emitLengthCheck n good bad γ = [||
 {- General Operations -}
 dup :: Defunc x -> (Defunc x -> Code r) -> Code r
 dup (FREEVAR x) k = k (FREEVAR x)
+dup (INPUT o pos) k = k (INPUT o pos)
 dup x k = [|| let !dupx = $$(genDefunc x) in $$(k (FREEVAR [||dupx||])) ||]
 
 {-# INLINE returnST #-}
@@ -99,23 +100,23 @@ class HandlerOps o where
   buildHandler :: BoxOps o
                => Γ s o xs n r a
                -> (Γ s o (o : xs) n r a -> Code (ST s (Maybe a)))
-               -> Code o -> Code (Handler s o a)
+               -> Code o -> (Code Int, Code Int) -> Code (Handler s o a)
   fatal :: Code (Handler s o a)
   raise :: BoxOps o => Γ s o xs (Succ n) r a -> Code (ST s (Maybe a))
 
 setupHandler :: Γ s o xs n r a
-             -> (Code o -> Code (Handler s o a))
+             -> (Code o -> (Code Int, Code Int) -> Code (Handler s o a))
              -> (Γ s o xs (Succ n) r a -> Code (ST s (Maybe a))) -> Code (ST s (Maybe a))
 setupHandler γ h k = [||
-    let handler = $$(h (input γ))
+    let handler = $$(h (input γ) (pos γ))
     in $$(k (γ {handlers = VCons [||handler||] (handlers γ)}))
   ||]
 
 #define deriveHandlerOps(_o)                         \
 instance HandlerOps _o where                         \
 {                                                    \
-  buildHandler γ h c = [||\(o# :: Unboxed _o) !(line :: Int) !(col :: Int) ->     \
-    $$(h (γ {operands = Op (FREEVAR c) (operands γ), \
+  buildHandler γ h c pos = [||\(o# :: Unboxed _o) !(line :: Int) !(col :: Int) ->     \
+    $$(h (γ {operands = Op (INPUT c pos) (operands γ), \
              input = [||$$box o#||], pos = ([||line||], [||col||])}))||];           \
   fatal = [||\(!_) !_ !_ -> returnST Nothing ||];          \
   raise γ = let VCons h _ = handlers γ               \
@@ -158,7 +159,7 @@ class BoxOps o => JoinBuilder o where
 class BoxOps o => RecBuilder o where
   buildIter :: ReturnOps o
             => Ctx s o a -> MVar Void -> Machine s o '[] One Void a
-            -> (Code o -> Code (Handler s o a)) -> Code o -> (Code Int, Code Int) -> Code (ST s (Maybe a))
+            -> (Code o -> (Code Int, Code Int) -> Code (Handler s o a)) -> Code o -> (Code Int, Code Int) -> Code (ST s (Maybe a))
   buildRec  :: MVar r
             -> Regs rs
             -> Ctx s o a
@@ -181,10 +182,10 @@ inputInstances(deriveJoinBuilder)
 instance RecBuilder _o where                                                     \
 {                                                                                \
   buildIter ctx μ l h o (line, col) = let bx = box in [||                                    \
-      let handler !o# !line !col = $$(h [||$$bx o#||]) line col;                                     \
+      let handler !o# !line !col = $$(h [||$$bx o#||] ([||line||], [||col||]));           \
           loop !o# !line !col =                                                             \
         $$(run l                                                                 \
-            (Γ Empty (noreturn @_o) [||$$bx o#||] ([||line||], [||col||]) (VCons [||handler o#||] VNil)) \
+            (Γ Empty (noreturn @_o) [||$$bx o#||] ([||line||], [||col||]) (VCons [||handler o# line col||] VNil)) \
             (voidCoins (insertSub μ [||\_ (!o#) !line !col _ -> loop o# line col||] ctx)))           \
       in loop ($$unbox $$o) $$line $$col                                                      \
     ||];                                                                         \
@@ -200,7 +201,7 @@ takeFreeRegisters (FreeReg σ σs) ctx body = [||\(!reg) -> $$(takeFreeRegisters
 
 {- Debugger Operations -}
 class (BoxOps o, PositionOps o, LogOps o) => LogHandler o where
-  logHandler :: (?ops :: InputOps o) => String -> Ctx s o a -> Γ s o xs (Succ n) ks a -> Code o -> Code (Handler s o a)
+  logHandler :: (?ops :: InputOps o) => String -> Ctx s o a -> Γ s o xs (Succ n) ks a -> Code o -> (Code Int, Code Int) -> Code (Handler s o a)
 
 preludeString :: (?ops :: InputOps o, PositionOps o, LogOps o) => String -> Char -> Γ s o xs n r a -> Ctx s o a -> String -> Code String
 preludeString name dir γ ctx ends = [|| concat [$$prelude, $$eof, ends, '\n' : $$caretSpace, color Blue "^"] ||]
@@ -223,7 +224,7 @@ preludeString name dir γ ctx ends = [|| concat [$$prelude, $$eof, ends, '\n' : 
 #define deriveLogHandler(_o)                                                                         \
 instance LogHandler _o where                                                                         \
 {                                                                                                    \
-  logHandler name ctx γ _ = let VCons h _ = handlers γ in [||\(!o#) ->                               \
+  logHandler name ctx γ _ _ = let VCons h _ = handlers γ in [||\(!o#) ->                             \
       trace $$(preludeString name '<' (γ {input = [||$$box o#||]}) ctx (color Red " Fail")) ($$h o#) \
     ||];                                                                                             \
 };

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/CodeGenerator.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/CodeGenerator.hs
@@ -118,7 +118,7 @@ addCoinsNeeded = coinsNeeded >>= addCoins
 
 shallow :: Trace => Combinator (CodeGen o a) x -> Fix4 (Instr o) (x : xs) (Succ n) r a -> CodeGenStack (Fix4 (Instr o) xs (Succ n) r a)
 shallow (Pure x)      m = do return $! In4 (Push (user x) m)
-shallow (Satisfy p)   m = do return $! In4 (Sat (user p) m)
+shallow (Satisfy p)   m = do return $! In4 (Sat p m)
 shallow (pf :<*>: px) m = do pxc <- runCodeGen px (In4 (_App m)); runCodeGen pf pxc
 shallow (p :*>: q)    m = do qc <- runCodeGen q m; runCodeGen p (In4 (Pop qc))
 shallow (p :<*: q)    m = do qc <- runCodeGen q (In4 (Pop m)); runCodeGen p qc

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/Instructions.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/Instructions.hs
@@ -74,7 +74,7 @@ data Instr (o :: Type)                                  -- The FIXED input type
             -> Instr o k (y : x : xs) n r a
   {-| Reads a character so long as it matches a given predicate. If it does not, or no input is available, this instruction fails.
 
-  @since 1.0.0.0 -}
+  @since 2.1.0.0 -}
   Sat       :: CharPred                   {- ^ Predicate to apply. -}
             -> k (Char : xs) (Succ n) r a {- ^ Machine requiring read character. -}
             -> Instr o k xs (Succ n) r a

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/Instructions.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/Instructions.hs
@@ -35,6 +35,7 @@ import Parsley.Internal.Backend.Machine.Identifiers (MVar, ΦVar, ΣVar)
 import Parsley.Internal.Backend.Machine.Types.Coins (Coins(Coins))
 import Parsley.Internal.Common                      (IFunctor4, Fix4(In4), Const4(..), imap4, cata4, Nat(..), One, intercalateDiff)
 import Parsley.Internal.Core.CombinatorAST          (PosSelector(..))
+import Parsley.Internal.Core.CharPred               (CharPred)
 
 import Parsley.Internal.Backend.Machine.Defunc as Machine (Defunc, user)
 import Parsley.Internal.Core.Defunc            as Core    (Defunc(ID), pattern FLIP_H)
@@ -74,8 +75,8 @@ data Instr (o :: Type)                                  -- The FIXED input type
   {-| Reads a character so long as it matches a given predicate. If it does not, or no input is available, this instruction fails.
 
   @since 1.0.0.0 -}
-  Sat       :: Machine.Defunc (Char -> Bool) {- ^ Predicate to apply. -}
-            -> k (Char : xs) (Succ n) r a    {- ^ Machine requiring read character. -}
+  Sat       :: CharPred                   {- ^ Predicate to apply. -}
+            -> k (Char : xs) (Succ n) r a {- ^ Machine requiring read character. -}
             -> Instr o k xs (Succ n) r a
   {-| Calls another let-bound parser.
 

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/LetBindings.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/LetBindings.hs
@@ -12,20 +12,21 @@ free registers.
 @since 1.0.0.0
 -}
 module Parsley.Internal.Backend.Machine.LetBindings (
-    LetBinding(..), Metadata, InputCharacteristic(..),
+    LetBinding(..), Metadata,
     Regs(..),
     makeLetBinding, newMeta,
     successInputCharacteristic, failureInputCharacteristic,
     Binding
   ) where
 
-import Prelude hiding                                (foldr)
-import Data.Kind                                     (Type)
-import Data.Set                                      (Set, foldr)
-import Data.Some                                     (Some, pattern Some)
-import Parsley.Internal.Backend.Machine.Identifiers  (ΣVar, SomeΣVar(..))
-import Parsley.Internal.Backend.Machine.Instructions (Instr)
-import Parsley.Internal.Common                       (Fix4, One)
+import Prelude hiding                                             (foldr)
+import Data.Kind                                                  (Type)
+import Data.Set                                                   (Set, foldr)
+import Data.Some                                                  (Some, pattern Some)
+import Parsley.Internal.Backend.Machine.Identifiers               (ΣVar, SomeΣVar(..))
+import Parsley.Internal.Backend.Machine.Instructions              (Instr)
+import Parsley.Internal.Backend.Machine.Types.InputCharacteristic (InputCharacteristic(..))
+import Parsley.Internal.Common                                    (Fix4, One)
 
 {-|
 Type represents a binding, which is a completed parser that can
@@ -74,24 +75,6 @@ data Metadata = Metadata {
     -}
     failureInputCharacteristic :: InputCharacteristic
   }
-
-{-|
-Provides a way to describe how input is consumed in certain circumstances:
-
-* The input may be always the same on all paths
-* The input may always be consumed, but not the same on all paths
-* The input may never be consumed in any path
-* It may be inconsistent
-
-@since 1.5.0.0
--}
-data InputCharacteristic = AlwaysConsumes (Maybe Word)
-                         -- ^ On all paths, input must be consumed: `Nothing` when the extact
-                         --   amount is inconsistent across paths.
-                         | NeverConsumes
-                         -- ^ On all paths, no input is consumed.
-                         | MayConsume
-                         -- ^ The input characteristic is unknown or inconsistent.
 
 {-|
 Given a `Binding` , a set of existential `ΣVar`s, and some `Metadata`, produces a

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/Types/InputCharacteristic.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/Types/InputCharacteristic.hs
@@ -1,0 +1,21 @@
+module Parsley.Internal.Backend.Machine.Types.InputCharacteristic (
+    module Parsley.Internal.Backend.Machine.Types.InputCharacteristic
+  ) where
+
+{-|
+Provides a way to describe how input is consumed in certain circumstances:
+
+* The input may be always the same on all paths
+* The input may always be consumed, but not the same on all paths
+* The input may never be consumed in any path
+* It may be inconsistent
+
+@since 1.5.0.0
+-}
+data InputCharacteristic = AlwaysConsumes (Maybe Word)
+                         -- ^ On all paths, input must be consumed: `Nothing` when the extact
+                         --   amount is inconsistent across paths.
+                         | NeverConsumes
+                         -- ^ On all paths, no input is consumed.
+                         | MayConsume
+                         -- ^ The input characteristic is unknown or inconsistent.

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/Types/InputCharacteristic.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/Types/InputCharacteristic.hs
@@ -1,3 +1,14 @@
+{-|
+Module      : Parsley.Internal.Backend.Machine.Types.InputCharacteristic
+Description : Packaging of offsets and positions.
+License     : BSD-3-Clause
+Maintainer  : Jamie Willis
+Stability   : experimental
+
+This module contains the `InputCharacteristic` datatype, that describes how bindings consume input.
+
+@since 2.1.0.0
+-}
 module Parsley.Internal.Backend.Machine.Types.InputCharacteristic (
     module Parsley.Internal.Backend.Machine.Types.InputCharacteristic
   ) where
@@ -10,7 +21,7 @@ Provides a way to describe how input is consumed in certain circumstances:
 * The input may never be consumed in any path
 * It may be inconsistent
 
-@since 1.5.0.0
+@since 2.1.0.0
 -}
 data InputCharacteristic = AlwaysConsumes (Maybe Word)
                          -- ^ On all paths, input must be consumed: `Nothing` when the extact

--- a/parsley-core/src/ghc/Parsley/Internal/Common/Queue.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Common/Queue.hs
@@ -13,9 +13,9 @@ Exposes the instance of `QueueLike` for `Queue`.
 module Parsley.Internal.Common.Queue (module Queue) where
 
 import Parsley.Internal.Common.Queue.Impl as Queue (
-    Queue, empty, enqueue, dequeue, null, size, foldr, enqueueAll
+    Queue, empty, enqueue, dequeue, null, size, foldr, enqueueAll, poke
   )
-import Parsley.Internal.Common.QueueLike  (QueueLike(empty, null, size, enqueue, dequeue, enqueueAll))
+import Parsley.Internal.Common.QueueLike  (QueueLike(empty, null, size, enqueue, dequeue, enqueueAll, poke))
 
 instance QueueLike Queue where
   empty      = Queue.empty
@@ -24,3 +24,4 @@ instance QueueLike Queue where
   enqueue    = Queue.enqueue
   dequeue    = Queue.dequeue
   enqueueAll = Queue.enqueueAll
+  poke       = Queue.poke

--- a/parsley-core/src/ghc/Parsley/Internal/Common/Queue/Impl.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Common/Queue/Impl.hs
@@ -68,6 +68,17 @@ dequeue q@(outs -> [])
   | otherwise   = error "dequeue of empty queue"
 
 {-|
+modifies the head of the queue, without removal. Returns the old head
+
+@since 2.1.0.0
+-}
+poke :: (a -> a) -> Queue a -> (a, Queue a)
+poke f q@(outs -> (x:outs')) = (x, q {outs = f x : outs'})
+poke f q@(outs -> [])
+  | insz q /= 0 = poke f (Queue (insz q) (reverse (ins q)) 0 [])
+  | otherwise   = error "poke of empty queue"
+
+{-|
 Is the queue empty?
 
 @since 1.5.0.0

--- a/parsley-core/src/ghc/Parsley/Internal/Common/QueueLike.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Common/QueueLike.hs
@@ -49,6 +49,12 @@ class QueueLike q where
   -}
   dequeue    :: q a -> (a, q a)
   {-|
+  modifies the head of the queue, without removal. Returns the old head
+
+  @since 2.1.0.0
+  -}
+  poke :: (a -> a) -> q a -> (a, q a)
+  {-|
   Adds each of the elements onto the queue, from left-to-right.
 
   @since 1.5.0.0

--- a/parsley-core/src/ghc/Parsley/Internal/Common/RangeSet.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Common/RangeSet.hs
@@ -319,7 +319,7 @@ intersection t1@(Fork _ _ l1 u1 lt1 rt1) t2 =
     Tip -> unsafeMerge lt1lt2 rt1rt2
     Fork 1 sz x y _ _
       | x == l1, y == u1
-      , lt1lt2 `ptrEq` lt1, rt1rt2 `ptrEq` rt2 -> t1
+      , lt1lt2 `ptrEq` lt1, rt1rt2 `ptrEq` rt1 -> t1
       | otherwise -> unsafeLink sz x y lt1lt2 rt1rt2
     Fork _ sz x y lt' rt' -> unsafeLink (sz - size lt' - size rt') x y (unsafeMerge lt1lt2 lt') (unsafeMerge rt' rt1rt2)
   where

--- a/parsley-core/src/ghc/Parsley/Internal/Common/RangeSet.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Common/RangeSet.hs
@@ -70,6 +70,7 @@ height :: RangeSet a -> Int
 height Tip = 0
 height (Fork h _ _ _ _) = h
 
+-- TODO: Size is more important now, make it O(1)!
 size :: (Num a, Enum a) => RangeSet a -> Int
 size = fold (\(!l) (!u) szl szr -> szl + szr + rangeSize l u) 0
 
@@ -329,7 +330,7 @@ union t = foldr insert t . elems
 
 -- TODO: This can be /much much/ better
 intersection :: (Enum a, Ord a) => RangeSet a -> RangeSet a -> RangeSet a
-intersection t = fromList . filter (flip member t) . elems
+intersection t = fromList . filter (`member` t) . elems
                  -- difference t . complement <- good if difference is optimised
 
 -- TODO: This can be /much much/ better
@@ -342,7 +343,7 @@ data StrictMaybe a = SJust !a | SNothing
 complement :: forall a. (Bounded a, Enum a, Eq a) => RangeSet a -> RangeSet a
 complement Tip = single minBound maxBound
 complement (Fork _ l u Tip Tip) | l == minBound, u == maxBound = Tip
-complement t@(Fork{}) = t'''
+complement t@Fork{} = t'''
   where
     (# !min, !min' #) = unsafeMinRange t
 
@@ -416,6 +417,7 @@ fold fork tip (Fork _ l u lt rt) = fork l u (fold fork tip lt) (fold fork tip rt
 
 -- Instances
 instance Eq a => Eq (RangeSet a) where
+  -- TODO: When size is faster, add the size check in
   t1 == t2 = {-(size t1 == size t2) && (-}ranges t1 == ranges t2--)
 
 -- Testing Utilities

--- a/parsley-core/src/ghc/Parsley/Internal/Common/RangeSet.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Common/RangeSet.hs
@@ -338,7 +338,7 @@ intersection t = fromList . filter (`member` t) . elems
                  -- difference t . complement <- good if difference is optimised
 
 -- TODO: This can be done better
-disjoint :: (Enum a, Ord a) => RangeSet a -> RangeSet a -> RangeSet a
+disjoint :: (Enum a, Ord a) => RangeSet a -> RangeSet a -> Bool
 disjoint t1 t2 = null (intersection t1 t2)
 
 -- TODO: This can be /much much/ better

--- a/parsley-core/src/ghc/Parsley/Internal/Common/RangeSet.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Common/RangeSet.hs
@@ -1,37 +1,42 @@
+{-# LANGUAGE DerivingStrategies #-}
 module Parsley.Internal.Common.RangeSet (
-    RangeSet,
-    empty, null, size,
-    member, notMember,
-    insert,
+    RangeSet(..),
+    empty, null, size, sizeRanges,
+    member, notMember, findMin, findMax,
+    insert, delete,
     union, intersection, difference,
-    elems, fromRanges, fromList
+    elems, fromRanges, insertRange, fromList,
+    -- Testing
+    valid
   ) where
 
 import Prelude hiding (null)
-import Data.Ix (Ix)
-
-import qualified Data.Ix as Ix
+import Control.Applicative (liftA2)
 
 {-# INLINE rangeSize #-}
-rangeSize :: Ix a => a -> a -> Int
-rangeSize l u = Ix.rangeSize (l, u)
+rangeSize :: (Enum a, Num a) => a -> a -> Int
+rangeSize l u = fromEnum (u - l) + 1
 
 {-# INLINE inRange #-}
-inRange :: Ix a => a -> a -> a -> Bool
-inRange l u = Ix.inRange (l, u)
+inRange :: Ord a => a -> a -> a -> Bool
+inRange l u x = l <= x && x <= u
 
 {-# INLINE range #-}
-range :: Ix a => a -> a -> [a]
-range l u = Ix.range (l, u)
+range :: Enum a => a -> a -> [a]
+range l u = [l..u]
 
 data RangeSet a = Fork {-# UNPACK #-} !Int !a !a !(RangeSet a) !(RangeSet a)
                 | Tip
+                deriving stock (Eq, Show)
 
 empty :: RangeSet a
 empty = Tip
 
 fork :: a -> a -> RangeSet a -> RangeSet a -> RangeSet a
 fork !l !u !lt !rt = Fork (max (height lt) (height rt) + 1) l u lt rt
+
+single :: a -> a -> RangeSet a
+single !l !u = Fork 1 l u Tip Tip
 
 null :: RangeSet a -> Bool
 null Tip = True
@@ -42,10 +47,13 @@ height :: RangeSet a -> Int
 height Tip = 0
 height (Fork h _ _ _ _) = h
 
-size :: Ix a => RangeSet a -> Int
+size :: (Num a, Enum a) => RangeSet a -> Int
 size = foldRangeSet (\(!l) (!u) szl szr -> szl + szr + rangeSize l u) 0
 
-member :: Ix a => a -> RangeSet a -> Bool
+sizeRanges :: RangeSet a -> Int
+sizeRanges = foldRangeSet (\_ _ szl szr -> szl + szr + 1) 0
+
+member :: Ord a => a -> RangeSet a -> Bool
 member x = foldRangeSet (\(!l) (!u) lt rt -> inRange l u x || (x > u && rt) || lt) False
 {-member !x (Fork _ l u lt rt)
   | inRange l u x       = True
@@ -53,20 +61,123 @@ member x = foldRangeSet (\(!l) (!u) lt rt -> inRange l u x || (x > u && rt) || l
   | otherwise {-x < l-} = member x lt
 member _ Tip = False-}
 
-notMember :: Ix a => a -> RangeSet a -> Bool
+notMember :: Ord a => a -> RangeSet a -> Bool
 notMember x = not . member x
 
-insert :: (Enum a, Ix a) => a -> RangeSet a -> RangeSet a
-insert x Tip = fork x x Tip Tip
+insert :: (Enum a, Ord a) => a -> RangeSet a -> RangeSet a
+insert x Tip = single x x
 insert x t@(Fork _ l u lt rt)
   -- Nothing happens when it's already in range
   | inRange l u x = t
   -- If it is adjacent to the lower or upper range, it may fuse with adjacent ranges
-  --  | x == pred l = undefined
-  --  | x == succ u = undefined
+  | x < l, x == pred l = fuseLeft x u lt rt
+  | x > u, x == succ u = fuseRight l x lt rt
   -- Otherwise, insert and balance for one of the left or the right
-  | x < l = balanceL l u (insert x lt) rt
-  | otherwise = balanceR l u lt (insert x rt)
+  | x < l = balance l u (insert x lt) rt     -- cannot be biased, because fusion can shrink a tree
+  | otherwise = balance l u lt (insert x rt) -- cannot be biased, because fusion can shrink a tree
+  where
+    fuseLeft x u lt rt
+      | not (null lt)
+      , (l, x') <- unsafeMaxRange lt
+      -- we know there exists an element larger than x'
+      -- if x == x' or x == x' + 1, we fuse
+      -- x >= x' since it is one less than x''s strict upper bound
+      -- x >= x' && (x == x' || x == x' + 1) === x >= x' && x <= x' + 1
+      , x <= succ x' = balanceR l u (unsafeDeleteRange l x' lt) rt
+      | otherwise    = fork x u lt rt
+    fuseRight l x lt rt
+      | not (null rt)
+      , (x', u) <- unsafeMinRange rt
+      -- we know there exists an element smaller than x'
+      -- if x == x' or x == x' - 1, we fuse
+      -- x <= x' since it is one greater than x''s strict lower bound,
+      -- x <= x' && (x == x' || x == x' - 1) === x <= x' && x >= x' - 1
+      , x >= pred x' = balanceL l u lt (unsafeDeleteRange x' u rt)
+      | otherwise    = fork l x lt rt
+
+delete :: (Enum a, Ord a) => a -> RangeSet a -> RangeSet a
+delete _ Tip = Tip
+delete x (Fork h l u lt rt)
+  -- If its the only part of the range, the node is removed
+  | l == x, x == u = pullup lt rt
+  -- If it's at an extreme, it shrinks the range
+  | l == x = Fork h (succ l) u lt rt
+  | x == u = Fork h l (pred u) lt rt
+  -- Otherwise, if it's still in range, the range undergoes fission
+  | inRange l u x = fission l x u lt rt
+  -- Otherwise delete and balance for one of the left or right
+  | x < l = balance l u (delete x lt) rt     -- cannot be biased, because fisson can grow a tree
+  | otherwise = balance l u lt (delete x rt) -- cannot be biased, because fisson can grow a tree
+  where
+    pullup Tip rt = rt
+    pullup lt Tip = lt
+    -- Both lt and rt are known to be non-empty
+    -- We'll pull the new parent element arbitrarily from the right
+    pullup lt rt  =
+      let (l, u) = unsafeMinRange rt
+          rt' = unsafeDeleteRange l u rt
+      in balanceL l u lt rt'
+
+    {-| Fission breaks a node into two new ranges
+        we'll push the range down into the right arbitrarily
+        To do this, we have to make it a child of the right-tree's left most position. -}
+    fission l1 x u2 lt rt =
+      let u1 = pred x
+          l2 = succ x
+          rt' = unsafeInsertRange l2 u2 rt
+      in balanceR l1 u1 lt rt'
+
+{-|
+This inserts a range which does not overlap with any other range within the tree.
+It *must* be /known/ not to exist within the tree.
+-}
+unsafeInsertRange :: Ord a => a -> a -> RangeSet a -> RangeSet a
+unsafeInsertRange l u Tip = single l u
+unsafeInsertRange l u (Fork _ l' u' lt rt)
+  | u < l' = balanceL l' u' (unsafeInsertRange l u lt) rt
+  | otherwise = balanceR l' u' lt (unsafeInsertRange l u rt)
+
+{-|
+This deletes a range which occurs /exactly/ as specific at the extremities of the tree.
+It *must not* be used with an empty tree, and it *must not* be used with a range that may
+overlap several elements or be contained within another range. The range to be removed *must* occur
+at a semi-leaf node (with at least one Tip).
+-}
+unsafeDeleteRange :: Ord a => a -> a -> RangeSet a -> RangeSet a
+unsafeDeleteRange l u (Fork _ l' u' lt Tip) | l == l', u == u' = lt
+unsafeDeleteRange l u (Fork _ l' u' Tip rt) | l == l', u == u' = rt
+unsafeDeleteRange l u t@(Fork _ l' u' lt rt)
+ | l < l' = balanceR l' u' (unsafeDeleteRange l u lt) rt
+ | u > u' = balanceL l' u' lt (unsafeDeleteRange l u rt)
+ | otherwise = t
+unsafeDeleteRange _ _ Tip = error "unsafeDeleteRange called on empty tree"
+
+findMin :: Ord a => RangeSet a -> Maybe a
+findMin Tip = Nothing
+findMin t = Just (fst (unsafeMinRange t))
+
+-- | Should /not/ be called with an empty tree!
+unsafeMinRange :: Ord a => RangeSet a -> (a, a)
+unsafeMinRange (Fork _ l u Tip _) = (l, u)
+unsafeMinRange (Fork _ _ _ lt _) = unsafeMinRange lt
+unsafeMinRange Tip = error "unsafeMinRange called on empty tree"
+
+findMax :: Ord a => RangeSet a -> Maybe a
+findMax Tip = Nothing
+findMax t = Just (snd (unsafeMaxRange t))
+
+-- | Should /not/ be called with an empty tree!
+unsafeMaxRange :: Ord a => RangeSet a -> (a, a)
+unsafeMaxRange (Fork _ l u _ Tip) = (l, u)
+unsafeMaxRange (Fork _ _ _ _ rt) = unsafeMaxRange rt
+unsafeMaxRange Tip = error "unsafeMaxRange called on empty tree"
+
+{-# NOINLINE balance #-}
+balance :: a -> a -> RangeSet a -> RangeSet a -> RangeSet a
+balance l u lt rt
+  | height lt > height rt + 1 = balanceL l u lt rt
+  | height rt > height lt + 1 = balanceR l u lt rt
+  | otherwise = fork l u lt rt
 
 {-# NOINLINE balanceL #-}
 balanceL :: a -> a -> RangeSet a -> RangeSet a -> RangeSet a
@@ -81,7 +192,9 @@ balanceL l1 u1 lt@(Fork !hlt l2 u2 llt rlt) rt
     !dltrt = hlt - height rt
     !hllt = height llt
     !hrlt = height rlt
-balanceL _ _ _ _ = error "Left tree didn't grow (or right didn't shrink), but balanceL was called!"
+-- If the right shrank (or nothing changed), we have to be prepared to handle the Tip case for lt
+balanceL l u Tip rt | height rt <= 1 = fork l u rt Tip
+balanceL _ _ Tip _ = error "Right should have shrank, but is still 1 taller than a Tip!"
 
 {-# NOINLINE balanceR #-}
 balanceR :: a -> a -> RangeSet a -> RangeSet a -> RangeSet a
@@ -96,7 +209,9 @@ balanceR l1 u1 lt rt@(Fork !hrt l2 u2 lrt rrt)
     !drtlt = hrt - height lt
     !hlrt = height lrt
     !hrrt = height rrt
-balanceR _ _ _ _ = error "Right tree didn't grow (or left didn't shrink), but balanceR was called!"
+-- If the left shrank (or nothing changed), we have to be prepared to handle the Tip case for rt
+balanceR l u lt Tip | height lt <= 1 = fork l u lt Tip
+balanceR _ _ _ Tip = error "Left should have shrank, but is still 1 taller than a Tip!"
 
 {-# INLINE rotr #-}
 rotr :: a -> a -> RangeSet a -> RangeSet a -> RangeSet a
@@ -109,27 +224,61 @@ rotl l1 u1 p (Fork _ l2 u2 q r) = fork l2 u2 (fork l1 u1 p q) r
 rotl _ _ _ _ = error "rotr on Tip"
 
 -- TODO: This can be /much much/ better
-union :: (Enum a, Ix a) => RangeSet a -> RangeSet a -> RangeSet a
+union :: (Enum a, Ord a) => RangeSet a -> RangeSet a -> RangeSet a
 union t = foldr insert t . elems
 
 -- TODO: This can be /much much/ better
-intersection :: (Enum a, Ix a) => RangeSet a -> RangeSet a -> RangeSet a
+intersection :: (Enum a, Ord a) => RangeSet a -> RangeSet a -> RangeSet a
 intersection t = fromList . filter (flip member t) . elems
 
 -- TODO: This can be /much much/ better
-difference :: (Enum a, Ix a) => RangeSet a -> RangeSet a -> RangeSet a
-difference t1 t2 = fromList (filter (not . flip member t2) (elems t1))
+difference :: (Enum a, Ord a) => RangeSet a -> RangeSet a -> RangeSet a
+difference t = foldr delete t . elems
 
-elems :: Ix a => RangeSet a -> [a]
+elems :: Enum a => RangeSet a -> [a]
 elems t = foldRangeSet (\l u lt rt -> lt . (range l u ++) . rt) id t []
 
 -- TODO: This can be /much much/ better
-fromRanges :: (Enum a, Ix a) => [(a, a)] -> RangeSet a
-fromRanges = fromList . concatMap Ix.range
+fromRanges :: (Enum a, Ord a) => [(a, a)] -> RangeSet a
+fromRanges = fromList . concatMap (uncurry range)
 
-fromList :: (Enum a, Ix a) => [a] -> RangeSet a
+insertRange :: (Enum a, Ord a) => (a, a) -> RangeSet a -> RangeSet a
+insertRange = union . fromRanges . pure
+
+fromList :: (Enum a, Ord a) => [a] -> RangeSet a
 fromList = foldr insert empty
 
 foldRangeSet :: (a -> a -> b -> b -> b) -> b -> RangeSet a -> b
 foldRangeSet _ tip Tip = tip
 foldRangeSet fork tip (Fork _ l u lt rt) = fork l u (foldRangeSet fork tip lt) (foldRangeSet fork tip rt)
+
+-- Testing Utilities
+
+valid :: (Ord a, Enum a) => RangeSet a -> Bool
+valid t = balanced t && orderedNonOverlappingAndCompressed True t
+
+balanced :: RangeSet a -> Bool
+balanced Tip = True
+balanced (Fork h _ _ lt rt) =
+  h == max (height lt) (height rt) + 1 &&
+  height rt < h &&
+  abs (height lt - height rt) <= 1 &&
+  balanced lt &&
+  balanced rt
+
+orderedNonOverlappingAndCompressed :: (Enum a, Ord a) => Bool -> RangeSet a -> Bool
+orderedNonOverlappingAndCompressed checkCompressed = bounded (const True) (const True)
+  where
+    bounded _ _ Tip = True
+    bounded lo hi (Fork _ l u lt rt) =
+      l <= u &&
+      lo l &&
+      hi u &&
+      bounded lo (boundAbove l) lt &&
+      bounded (boundBelow u) hi rt
+
+    boundAbove l | checkCompressed = liftA2 (&&) (< l) (< pred l)
+                 | otherwise = (< l)
+
+    boundBelow u | checkCompressed = liftA2 (&&) (> u) (> succ u)
+                 | otherwise = (> u)

--- a/parsley-core/src/ghc/Parsley/Internal/Common/RangeSet.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Common/RangeSet.hs
@@ -1,0 +1,135 @@
+module Parsley.Internal.Common.RangeSet (
+    RangeSet,
+    empty, null, size,
+    member, notMember,
+    insert,
+    union, intersection, difference,
+    elems, fromRanges, fromList
+  ) where
+
+import Prelude hiding (null)
+import Data.Ix (Ix)
+
+import qualified Data.Ix as Ix
+
+{-# INLINE rangeSize #-}
+rangeSize :: Ix a => a -> a -> Int
+rangeSize l u = Ix.rangeSize (l, u)
+
+{-# INLINE inRange #-}
+inRange :: Ix a => a -> a -> a -> Bool
+inRange l u = Ix.inRange (l, u)
+
+{-# INLINE range #-}
+range :: Ix a => a -> a -> [a]
+range l u = Ix.range (l, u)
+
+data RangeSet a = Fork {-# UNPACK #-} !Int !a !a !(RangeSet a) !(RangeSet a)
+                | Tip
+
+empty :: RangeSet a
+empty = Tip
+
+fork :: a -> a -> RangeSet a -> RangeSet a -> RangeSet a
+fork !l !u !lt !rt = Fork (max (height lt) (height rt) + 1) l u lt rt
+
+null :: RangeSet a -> Bool
+null Tip = True
+null _ = False
+
+{-# INLINE height #-}
+height :: RangeSet a -> Int
+height Tip = 0
+height (Fork h _ _ _ _) = h
+
+size :: Ix a => RangeSet a -> Int
+size = foldRangeSet (\(!l) (!u) szl szr -> szl + szr + rangeSize l u) 0
+
+member :: Ix a => a -> RangeSet a -> Bool
+member x = foldRangeSet (\(!l) (!u) lt rt -> inRange l u x || (x > u && rt) || lt) False
+{-member !x (Fork _ l u lt rt)
+  | inRange l u x       = True
+  | x > u               = member x rt
+  | otherwise {-x < l-} = member x lt
+member _ Tip = False-}
+
+notMember :: Ix a => a -> RangeSet a -> Bool
+notMember x = not . member x
+
+insert :: (Enum a, Ix a) => a -> RangeSet a -> RangeSet a
+insert x Tip = fork x x Tip Tip
+insert x t@(Fork _ l u lt rt)
+  -- Nothing happens when it's already in range
+  | inRange l u x = t
+  -- If it is adjacent to the lower or upper range, it may fuse with adjacent ranges
+  --  | x == pred l = undefined
+  --  | x == succ u = undefined
+  -- Otherwise, insert and balance for one of the left or the right
+  | x < l = balanceL l u (insert x lt) rt
+  | otherwise = balanceR l u lt (insert x rt)
+
+{-# NOINLINE balanceL #-}
+balanceL :: a -> a -> RangeSet a -> RangeSet a -> RangeSet a
+-- PRE: left grew or right shrank, difference in height at most 2 biasing to the left
+balanceL l1 u1 lt@(Fork !hlt l2 u2 llt rlt) rt
+  -- both sides are equal height or off by one
+  | dltrt <= 1 = fork l1 u1 lt rt
+  -- The bias is 2 (dltrt == 2)
+  | hllt >= hrlt = rotr l1 u1 lt rt
+  | otherwise    = rotr l1 u1 (rotl l2 u2 llt rlt) rt
+  where
+    !dltrt = hlt - height rt
+    !hllt = height llt
+    !hrlt = height rlt
+balanceL _ _ _ _ = error "Left tree didn't grow (or right didn't shrink), but balanceL was called!"
+
+{-# NOINLINE balanceR #-}
+balanceR :: a -> a -> RangeSet a -> RangeSet a -> RangeSet a
+-- PRE: left shrank or right grew, difference in height at most 2 biasing to the right
+balanceR l1 u1 lt rt@(Fork !hrt l2 u2 lrt rrt)
+  -- both sides are equal height or off by one
+  | drtlt <= 1 = fork l1 u1 lt rt
+  -- The bias is 2 (drtlt == 2)
+  | hrrt >= hlrt = rotl l1 u1 lt rt
+  | otherwise    = rotl l1 u1 lt (rotr l2 u2 lrt rrt)
+  where
+    !drtlt = hrt - height lt
+    !hlrt = height lrt
+    !hrrt = height rrt
+balanceR _ _ _ _ = error "Right tree didn't grow (or left didn't shrink), but balanceR was called!"
+
+{-# INLINE rotr #-}
+rotr :: a -> a -> RangeSet a -> RangeSet a -> RangeSet a
+rotr l1 u1 (Fork _ l2 u2 p q) r = fork l2 u2 p (fork l1 u1 q r)
+rotr _ _ _ _ = error "rotr on Tip"
+
+{-# INLINE rotl #-}
+rotl :: a -> a -> RangeSet a -> RangeSet a -> RangeSet a
+rotl l1 u1 p (Fork _ l2 u2 q r) = fork l2 u2 (fork l1 u1 p q) r
+rotl _ _ _ _ = error "rotr on Tip"
+
+-- TODO: This can be /much much/ better
+union :: (Enum a, Ix a) => RangeSet a -> RangeSet a -> RangeSet a
+union t = foldr insert t . elems
+
+-- TODO: This can be /much much/ better
+intersection :: (Enum a, Ix a) => RangeSet a -> RangeSet a -> RangeSet a
+intersection t = fromList . filter (flip member t) . elems
+
+-- TODO: This can be /much much/ better
+difference :: (Enum a, Ix a) => RangeSet a -> RangeSet a -> RangeSet a
+difference t1 t2 = fromList (filter (not . flip member t2) (elems t1))
+
+elems :: Ix a => RangeSet a -> [a]
+elems t = foldRangeSet (\l u lt rt -> lt . (range l u ++) . rt) id t []
+
+-- TODO: This can be /much much/ better
+fromRanges :: (Enum a, Ix a) => [(a, a)] -> RangeSet a
+fromRanges = fromList . concatMap Ix.range
+
+fromList :: (Enum a, Ix a) => [a] -> RangeSet a
+fromList = foldr insert empty
+
+foldRangeSet :: (a -> a -> b -> b -> b) -> b -> RangeSet a -> b
+foldRangeSet _ tip Tip = tip
+foldRangeSet fork tip (Fork _ l u lt rt) = fork l u (foldRangeSet fork tip lt) (foldRangeSet fork tip rt)

--- a/parsley-core/src/ghc/Parsley/Internal/Common/RewindQueue.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Common/RewindQueue.hs
@@ -13,9 +13,9 @@ Exposes the instance of `QueueLike` for `RewindQueue`.
 module Parsley.Internal.Common.RewindQueue (module RewindQueue) where
 
 import Parsley.Internal.Common.RewindQueue.Impl as RewindQueue (
-    RewindQueue, empty, enqueue, dequeue, rewind, null, size, foldr, enqueueAll
+    RewindQueue, empty, enqueue, dequeue, rewind, null, size, foldr, enqueueAll, poke
   )
-import Parsley.Internal.Common.QueueLike  (QueueLike(empty, null, size, enqueue, dequeue, enqueueAll))
+import Parsley.Internal.Common.QueueLike  (QueueLike(empty, null, size, enqueue, dequeue, enqueueAll, poke))
 
 instance QueueLike RewindQueue where
   empty      = RewindQueue.empty
@@ -24,3 +24,4 @@ instance QueueLike RewindQueue where
   enqueue    = RewindQueue.enqueue
   dequeue    = RewindQueue.dequeue
   enqueueAll = RewindQueue.enqueueAll
+  poke       = RewindQueue.poke

--- a/parsley-core/src/ghc/Parsley/Internal/Common/RewindQueue/Impl.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Common/RewindQueue/Impl.hs
@@ -18,7 +18,7 @@ import Data.List (foldl')
 import Parsley.Internal.Common.Queue.Impl as Queue (Queue(..), toList)
 
 import qualified Parsley.Internal.Common.Queue.Impl as Queue (
-    empty, enqueue, enqueueAll, dequeue, null, size, foldr
+    empty, enqueue, enqueueAll, dequeue, null, size, foldr, poke
   )
 
 {-|
@@ -68,6 +68,14 @@ dequeue :: RewindQueue a -> (a, RewindQueue a)
 dequeue RewindQueue{..} =
   let (x, queue') = Queue.dequeue queue
   in (x, RewindQueue { queue = queue', undo = x : undo, undosz = undosz + 1 })
+
+{-|
+modifies the head of the queue, without removal. Returns the old head
+
+@since 2.1.0.0
+-}
+poke :: (a -> a) -> RewindQueue a -> (a, RewindQueue a)
+poke f q = let (x, queue') = Queue.poke f (queue q) in (x, q { queue = queue' })
 
 {-|
 Undoes the last \(n\) `dequeue` operations but /only/ if there are that many

--- a/parsley-core/src/ghc/Parsley/Internal/Core.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core.hs
@@ -9,10 +9,12 @@ Stability   : unstable
 -}
 module Parsley.Internal.Core (
     Parser,
+    module Parsley.Internal.Core.CharPred,
     module Parsley.Internal.Core.Defunc,
     module Parsley.Internal.Core.InputTypes
   ) where
 
+import Parsley.Internal.Core.CharPred (CharPred)
 import Parsley.Internal.Core.Defunc hiding (lamTerm)
 import Parsley.Internal.Core.InputTypes
 import Parsley.Internal.Core.Primitives (Parser)

--- a/parsley-core/src/ghc/Parsley/Internal/Core/CharPred.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/CharPred.hs
@@ -36,8 +36,15 @@ nonMembers (Ranges incl rngs)  = members (Ranges (not incl) rngs)
 invertRanges :: [(Char, Char)] -> [(Char, Char)]
 invertRanges rngs = foldr roll (\l -> [(l, maxBound)]) rngs minBound
   where
-    roll (u, l') next l = (if l == u then id else ((l, pred u) :))        -- If they are equal, no range
-                          (if l' == maxBound then [] else next (succ l')) -- If the upper-bound is the top, stop
+    roll (u, l') next l
+      -- If the lower and upper bounds are the same, there is no exclusive range
+      | l == u    = rest
+      | otherwise = (l, pred u) : rest
+      where
+        -- If the new lower-bound is the maxBound, this is the end
+        rest
+          | l' == maxBound = []
+          | otherwise      = next (succ l')
 
 lamTerm :: CharPred -> Lam (Char -> Bool)
 lamTerm (UserPred _ t) = t

--- a/parsley-core/src/ghc/Parsley/Internal/Core/CharPred.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/CharPred.hs
@@ -36,7 +36,8 @@ nonMembers (Ranges incl rngs)  = members (Ranges (not incl) rngs)
 invertRanges :: [(Char, Char)] -> [(Char, Char)]
 invertRanges rngs = foldr roll (\l -> [(l, maxBound)]) rngs minBound
   where
-    roll (u, l') next l = (l, u) : next l'
+    roll (u, l') next l = (if l == u then id else ((l, pred u) :))        -- If they are equal, no range
+                          (if l' == maxBound then [] else next (succ l')) -- If the upper-bound is the top, stop
 
 lamTerm :: CharPred -> Lam (Char -> Bool)
 lamTerm (UserPred _ t) = t

--- a/parsley-core/src/ghc/Parsley/Internal/Core/CharPred.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/CharPred.hs
@@ -1,79 +1,101 @@
+{-# LANGUAGE PatternSynonyms, ViewPatterns #-}
 module Parsley.Internal.Core.CharPred (
-    CharPred(..),
-    apply, andPred,
+    CharPred(..), pattern Item, pattern Specific,
+    apply, andPred, orPred, diffPred,
     members, nonMembers,
     lamTerm
   ) where
 
-import Data.List                     (intercalate, delete, nub)
-import Parsley.Internal.Core.Lam     (Lam(Abs, App, Var, T, F))
+import Prelude hiding (null)
+
+import Parsley.Internal.Common.RangeSet (RangeSet, elems, unelems, fromRanges, full, member, fold, null, union, extractSingle, singleton, intersection, difference)
+import Parsley.Internal.Core.Lam        (Lam(Abs, App, Var, T, F, If))
 
 data CharPred where
   UserPred :: (Char -> Bool) -> Lam (Char -> Bool) -> CharPred
-  Ranges :: Bool -> [(Char, Char)] -> CharPred
-  Item :: CharPred
-  Specific :: Char -> CharPred
-  -- TODO: And is pretty poor as an abstraction, we want to write a proper merge!
-  And :: CharPred -> CharPred -> CharPred
+  Ranges :: RangeSet Char -> CharPred
+
+pattern Item :: CharPred
+pattern Item <- Ranges (full -> True)
+  where Item = Ranges (fromRanges [(minBound, maxBound)])
+
+pattern Specific :: Char -> CharPred
+pattern Specific c <- Ranges (extractSingle -> Just c)
+  where Specific c = Ranges (singleton c)
 
 apply :: CharPred -> Char -> Bool
 apply (UserPred f _) c = f c
-apply (Ranges True rngs) c = any (\(l, u) -> l <= c || c <= u) rngs
-apply (Ranges False rngs) c = all (\(l, u) -> l >= c || c >= u) rngs
-apply (Specific c') c = c == c'
-apply Item _ = True
-apply (And p q) c = apply p c && apply q c
+apply (Ranges rngs) c = member c rngs
 
 andPred :: CharPred -> CharPred -> CharPred
-andPred = And
+andPred (UserPred f lf) p = UserPred (\c -> f c && apply p c) (Abs $ \c -> andLam (App lf c) (App (lamTerm p) c))
+andPred p (UserPred f lf) = UserPred (\c -> apply p c && f c) (Abs $ \c -> andLam (App (lamTerm p) c) (App lf c))
+andPred (Ranges rngs1) (Ranges rngs2) = Ranges (rngs1 `intersection` rngs2)
+
+orPred :: CharPred -> CharPred -> CharPred
+orPred (UserPred f lf) p = UserPred (\c -> f c || apply p c) (Abs $ \c -> orLam (App lf c) (App (lamTerm p) c))
+orPred p (UserPred f lf) = UserPred (\c -> apply p c || f c) (Abs $ \c -> orLam (App (lamTerm p) c) (App lf c))
+orPred (Ranges rngs1) (Ranges rngs2) = Ranges (rngs1 `union` rngs2)
+
+diffPred :: CharPred -> CharPred -> CharPred
+diffPred (UserPred f lf) p = UserPred (\c -> f c && not (apply p c)) (Abs $ \c -> andLam (App lf c) (notLam (App (lamTerm p) c)))
+diffPred p (UserPred f lf) = UserPred (\c -> apply p c && not (f c)) (Abs $ \c -> andLam (App (lamTerm p) c) (notLam (App lf c)))
+diffPred (Ranges rngs1) (Ranges rngs2) = Ranges (rngs1 `difference` rngs2)
+
+andLam :: Lam Bool -> Lam Bool -> Lam Bool
+andLam T y = y
+andLam x T = x
+andLam F _ = F
+andLam _ F = F
+andLam x y = App (App (Var True [||(&&)||]) x) y
+
+orLam :: Lam Bool -> Lam Bool -> Lam Bool
+orLam T _ = T
+orLam _ T = T
+orLam F y = y
+orLam y F = y
+orLam x y = App (App (Var True [||(||)||]) x) y
+
+notLam :: Lam Bool -> Lam Bool
+notLam T = F
+notLam F = T
+notLam x = App (Var True [||not||]) x
 
 members :: CharPred -> [Char]
-members (UserPred f _)      = filter f [minBound..maxBound]
-members Item                = [minBound..maxBound]
-members (Specific c)        = [c]
-members (Ranges incl rngs)  = concatMap (\(l, u) -> [l..u]) ((if incl then invertRanges else id) rngs)
-members (And p q)           = nub $ members p ++ members q -- TODO: Gross
+members (UserPred f _) = filter f [minBound..maxBound]
+members (Ranges rngs)  = elems rngs
 
 nonMembers :: CharPred -> [Char]
 nonMembers (UserPred f _)      = filter (not . f) [minBound..maxBound]
-nonMembers Item                = []
-nonMembers (Specific c)        = delete c [minBound..maxBound]
-nonMembers (Ranges incl rngs)  = members (Ranges (not incl) rngs)
-nonMembers (And p q)           = nub $ members p ++ members q
-
-invertRanges :: [(Char, Char)] -> [(Char, Char)]
-invertRanges rngs = foldr roll (\l -> [(l, maxBound)]) rngs minBound
-  where
-    roll (u, l') next l
-      -- If the lower and upper bounds are the same, there is no exclusive range
-      | l == u    = rest
-      | otherwise = (l, pred u) : rest
-      where
-        -- If the new lower-bound is the maxBound, this is the end
-        rest
-          | l' == maxBound = []
-          | otherwise      = next (succ l')
+nonMembers (Ranges rngs)       = unelems rngs
 
 lamTerm :: CharPred -> Lam (Char -> Bool)
 lamTerm (UserPred _ t) = t
-lamTerm (Specific c) = Abs $ \c' -> App (App (Var True [||(==)||]) c') (Var True [||c||])
 lamTerm Item = Abs (const T)
-lamTerm (Ranges incl []) = Abs (const (if incl then F else T))
-lamTerm (Ranges incl rngs) =
+lamTerm (Ranges (null -> True)) = Abs (const F)
+lamTerm (Ranges rngs) =
   Abs $ \c ->
-    App (if incl then Abs id else Var True [||not||])
-        (foldr1 (App . App (Var True [||(||)||]))
-          (map (\(l, u) ->
-            if l == u then App (App (Var True [||(==)||]) c) (Var True [||l||])
-                      else App (App (Var True [||(&&)||])
-                               (App (App (Var True [||(<=)||]) (Var True [||l||])) c))
-                               (App (App (Var True [||(<=)||]) c) (Var True [||u||])))
-           rngs))
-lamTerm (And p q) = Abs $ \c -> App (App (Var True [||(&&)||]) (App (lamTerm p) c)) (App (lamTerm q) c)
+    fold (conv c) F rngs
+  where
+    conv c l u lb rb
+    --  | l == u = eq c (Var True [||l||]) `or` (lb `or` rb)
+    --  | otherwise = (lte (Var True [||l||]) c `and` lte c (Var True [||u||])) `or` (lb `or` rb)
+      | l == u = eq c (Var True [||l||]) `or` if' (lt c (Var True [||l||])) lb rb
+      | otherwise = if' (lte (Var True [||l||]) c) (lte c (Var True [||u||]) `or` rb) lb
+
+    or = orLam
+    and = andLam
+    lte :: Lam Char -> Lam Char -> Lam Bool
+    lte = App . App (Var True [||(<=)||])
+    lt :: Lam Char -> Lam Char -> Lam Bool
+    lt = App . App (Var True [||(<)||])
+    eq :: Lam Char -> Lam Char -> Lam Bool
+    eq = App . App (Var True [||(==)||])
+    if' x y F = and x y
+    if' c x y = If c x y
 
 instance Show CharPred where
   show (UserPred _ f) = show f
   show Item = "const True"
   show (Specific c) = concat ["(== ", show c, ")"]
-  show (Ranges incl rngs) = concat [if incl then "not " else "", "elem (", intercalate " ++ " (map (\(l, u) -> concat ["[", show l, "..", show u, "]"]) rngs), ")"]
-  show (And p q) = concat ["liftA2 (&&) (", show p, ") (", show q, ")"]
+  show (Ranges rngs) = "elem " ++ show rngs

--- a/parsley-core/src/ghc/Parsley/Internal/Core/CharPred.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/CharPred.hs
@@ -1,0 +1,41 @@
+module Parsley.Internal.Core.CharPred (
+    module Parsley.Internal.Core.CharPred
+  ) where
+
+import Data.List                     (intercalate)
+import Parsley.Internal.Core.Lam     (Lam(Abs, App, Var, T, F))
+
+data CharPred where
+  UserPred :: (Char -> Bool) -> Lam (Char -> Bool) -> CharPred
+  Ranges :: Bool -> [(Char, Char)] -> CharPred
+  Item :: CharPred
+  Specific :: Char -> CharPred
+
+apply :: CharPred -> Char -> Bool
+apply (UserPred f _) c = f c
+apply (Ranges True rngs) c = any (\(l, u) -> l <= c || c <= u) rngs
+apply (Ranges False rngs) c = all (\(l, u) -> l >= c || c >= u) rngs
+apply (Specific c') c = c == c'
+apply Item _ = True
+
+lamTerm :: CharPred -> Lam (Char -> Bool)
+lamTerm (UserPred _ t) = t
+lamTerm (Specific c) = Abs $ \c' -> App (App (Var True [||(==)||]) c') (Var True [||c||])
+lamTerm Item = Abs (const T)
+lamTerm (Ranges incl []) = Abs (const (if incl then F else T))
+lamTerm (Ranges incl rngs) =
+  Abs $ \c ->
+    App (if incl then Abs id else Var True [||not||])
+        (foldr1 (App . App (Var True [||(||)||]))
+          (map (\(l, u) ->
+            if l == u then App (App (Var True [||(==)||]) c) (Var True [||l||])
+                      else App (App (Var True [||(&&)||])
+                               (App (App (Var True [||(<=)||]) (Var True [||l||])) c))
+                               (App (App (Var True [||(<=)||]) c) (Var True [||u||])))
+           rngs))
+
+instance Show CharPred where
+  show (UserPred _ f) = show f
+  show Item = "const True"
+  show (Specific c) = concat ["(== ", show c, ")"]
+  show (Ranges incl rngs) = concat [if incl then "not " else "", "elem (", intercalate " ++ " (map (\(l, u) -> concat ["[", show l, "..", show u, "]"]) rngs), ")"]

--- a/parsley-core/src/ghc/Parsley/Internal/Core/CharPred.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/CharPred.hs
@@ -13,6 +13,7 @@ data CharPred where
   Ranges :: Bool -> [(Char, Char)] -> CharPred
   Item :: CharPred
   Specific :: Char -> CharPred
+  -- TODO: And is pretty poor as an abstraction, we want to write a proper merge!
   And :: CharPred -> CharPred -> CharPred
 
 apply :: CharPred -> Char -> Bool

--- a/parsley-core/src/ghc/Parsley/Internal/Core/CharPred.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/CharPred.hs
@@ -1,11 +1,11 @@
 module Parsley.Internal.Core.CharPred (
     CharPred(..),
-    apply,
+    apply, andPred,
     members, nonMembers,
     lamTerm
   ) where
 
-import Data.List                     (intercalate, delete)
+import Data.List                     (intercalate, delete, nub)
 import Parsley.Internal.Core.Lam     (Lam(Abs, App, Var, T, F))
 
 data CharPred where
@@ -13,6 +13,7 @@ data CharPred where
   Ranges :: Bool -> [(Char, Char)] -> CharPred
   Item :: CharPred
   Specific :: Char -> CharPred
+  And :: CharPred -> CharPred -> CharPred
 
 apply :: CharPred -> Char -> Bool
 apply (UserPred f _) c = f c
@@ -20,18 +21,24 @@ apply (Ranges True rngs) c = any (\(l, u) -> l <= c || c <= u) rngs
 apply (Ranges False rngs) c = all (\(l, u) -> l >= c || c >= u) rngs
 apply (Specific c') c = c == c'
 apply Item _ = True
+apply (And p q) c = apply p c && apply q c
+
+andPred :: CharPred -> CharPred -> CharPred
+andPred = And
 
 members :: CharPred -> [Char]
 members (UserPred f _)      = filter f [minBound..maxBound]
 members Item                = [minBound..maxBound]
 members (Specific c)        = [c]
 members (Ranges incl rngs)  = concatMap (\(l, u) -> [l..u]) ((if incl then invertRanges else id) rngs)
+members (And p q)           = nub $ members p ++ members q -- TODO: Gross
 
 nonMembers :: CharPred -> [Char]
 nonMembers (UserPred f _)      = filter (not . f) [minBound..maxBound]
 nonMembers Item                = []
 nonMembers (Specific c)        = delete c [minBound..maxBound]
 nonMembers (Ranges incl rngs)  = members (Ranges (not incl) rngs)
+nonMembers (And p q)           = nub $ members p ++ members q
 
 invertRanges :: [(Char, Char)] -> [(Char, Char)]
 invertRanges rngs = foldr roll (\l -> [(l, maxBound)]) rngs minBound
@@ -61,9 +68,11 @@ lamTerm (Ranges incl rngs) =
                                (App (App (Var True [||(<=)||]) (Var True [||l||])) c))
                                (App (App (Var True [||(<=)||]) c) (Var True [||u||])))
            rngs))
+lamTerm (And p q) = Abs $ \c -> App (App (Var True [||(&&)||]) (App (lamTerm p) c)) (App (lamTerm q) c)
 
 instance Show CharPred where
   show (UserPred _ f) = show f
   show Item = "const True"
   show (Specific c) = concat ["(== ", show c, ")"]
   show (Ranges incl rngs) = concat [if incl then "not " else "", "elem (", intercalate " ++ " (map (\(l, u) -> concat ["[", show l, "..", show u, "]"]) rngs), ")"]
+  show (And p q) = concat ["liftA2 (&&) (", show p, ") (", show q, ")"]

--- a/parsley-core/src/ghc/Parsley/Internal/Core/CombinatorAST.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/CombinatorAST.hs
@@ -4,6 +4,7 @@ module Parsley.Internal.Core.CombinatorAST (module Parsley.Internal.Core.Combina
 import Data.Kind                         (Type)
 import Parsley.Internal.Common           (IFunctor(..), Fix, Const1(..), cata, intercalateDiff, (:+:))
 import Parsley.Internal.Core.Identifiers (MVar, ΣVar)
+import Parsley.Internal.Core.CharPred    (CharPred)
 import Parsley.Internal.Core.Defunc      (Defunc)
 
 {-|
@@ -16,7 +17,7 @@ newtype Parser a = Parser {unParser :: Fix (Combinator :+: ScopeRegister) a}
 -- Core datatype
 data Combinator (k :: Type -> Type) (a :: Type) where
   Pure           :: Defunc a -> Combinator k a
-  Satisfy        :: Defunc (Char -> Bool) -> Combinator k Char
+  Satisfy        :: CharPred -> Combinator k Char
   (:<*>:)        :: k (a -> b) -> k a -> Combinator k b
   (:*>:)         :: k a -> k b -> Combinator k b
   (:<*:)         :: k a -> k b -> Combinator k a

--- a/parsley-core/src/ghc/Parsley/Internal/Core/Defunc.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/Defunc.hs
@@ -14,14 +14,16 @@ terms that can be used by the user and the frontend.
 module Parsley.Internal.Core.Defunc (
     Defunc(..),
     pattern COMPOSE_H, pattern FLIP_H, pattern FLIP_CONST, pattern UNIT,
-    lamTerm
+    lamTerm, charPred
   ) where
 
-import Data.List                     (intercalate)
-import Data.Typeable                 (Typeable, (:~:)(Refl), eqT)
-import Language.Haskell.TH.Syntax    (Lift(..))
-import Parsley.Internal.Common.Utils (WQ(..), Code, Quapplicative(..))
-import Parsley.Internal.Core.Lam     (normaliseGen, Lam(..))
+import Data.Typeable                  (Typeable, (:~:)(Refl), eqT)
+import Language.Haskell.TH.Syntax     (Lift(..))
+import Parsley.Internal.Common.Utils  (WQ(..), Code, Quapplicative(..))
+import Parsley.Internal.Core.CharPred (CharPred(..))
+import Parsley.Internal.Core.Lam      (normaliseGen, Lam(..))
+
+import qualified Parsley.Internal.Core.CharPred as CharPred (lamTerm)
 
 {-|
 This datatype is useful for providing an /inspectable/ representation of common Haskell functions.
@@ -159,21 +161,20 @@ lamTerm CONS = Var True [||(:)||]
 lamTerm EMPTY = Var True [||[]||]
 lamTerm CONST = Abs (Abs . const)
 lamTerm (BLACK x) = Var False (_code x)
-lamTerm (RANGES incl []) = Abs (const (if incl then F else T))
-lamTerm (RANGES incl [(l, u)]) | l == minBound, u == maxBound = Abs (const (if incl then T else F))
-lamTerm (RANGES incl rngs) =
-  Abs $ \c ->
-    App (if incl then Abs id else Var True [||not||])
-        (foldr1 (App . App (Var True [||(||)||]))
-          (map (\(l, u) ->
-            if l == u then App (App (Var True [||(==)||]) c) (Var True [||l||])
-                      else App (App (Var True [||(&&)||])
-                               (App (App (Var True [||(<=)||]) (Var True [||l||])) c))
-                               (App (App (Var True [||(<=)||]) c) (Var True [||u||])))
-           rngs))
+lamTerm rngs@(RANGES _ _) = CharPred.lamTerm (charPred rngs)
 lamTerm (LAM_S f) = Abs (adaptLam f)
 lamTerm (IF_S c t e) = If (lamTerm c) (lamTerm t) (lamTerm e)
 lamTerm (LET_S x f) = Let (lamTerm x) (adaptLam f)
+
+charPred :: Defunc (Char -> Bool) -> CharPred
+charPred (EQ_H (LIFTED c)) = Specific c
+charPred (RANGES False []) = Item
+charPred (RANGES True [(l, u)]) | l == minBound, u == maxBound = Item
+charPred (RANGES True [(c, c')]) | c == c' = Specific c
+charPred (RANGES incl cs) = Ranges incl cs
+charPred (APP_H CONST (LIFTED True)) = Item
+charPred (APP_H CONST (LIFTED False)) = Ranges True []
+charPred p = UserPred (_val p) (lamTerm p)
 
 adaptLam :: (Defunc a -> Defunc b) -> (Lam a -> Lam b)
 adaptLam f = lamTerm . f . defuncTerm
@@ -204,5 +205,5 @@ instance Show (Defunc a) where
   show CONST = "const"
   show (IF_S c b e) = concat ["(if ", show c, " then ", show b, " else ", show e, ")"]
   show (LAM_S _) = "f"
-  show (RANGES incl rngs) = concat [if incl then "not " else "", "elem (", intercalate " ++ " (map (\(l, u) -> concat ["[", show l, "..", show u, "]"]) rngs), ")"]
+  show (RANGES incl rngs) = show (Ranges incl rngs)
   show _ = "x"

--- a/parsley-core/src/ghc/Parsley/Internal/Core/Primitives.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/Primitives.hs
@@ -7,7 +7,7 @@ module Parsley.Internal.Core.Primitives (
 
 import Prelude hiding                      (pure, (<*>))
 import Parsley.Internal.Core.CombinatorAST (Combinator(..), ScopeRegister(..), Reg(..), Parser(..), PosSelector(..))
-import Parsley.Internal.Core.Defunc        (Defunc)
+import Parsley.Internal.Core.Defunc        (Defunc, charPred)
 
 import Parsley.Internal.Common.Indexed     (Fix(In), (:+:)(..))
 
@@ -18,7 +18,7 @@ pure = Parser . In . L . Pure
 
 {-# INLINE satisfy #-}
 satisfy :: Defunc (Char -> Bool) -> Parser Char
-satisfy = Parser . In . L . Satisfy
+satisfy = Parser . In . L . Satisfy . charPred
 
 {-# INLINE conditional #-}
 conditional :: [(Defunc (a -> Bool), Parser b)] -> Parser a -> Parser b -> Parser b

--- a/parsley-core/test/CommonTest.hs
+++ b/parsley-core/test/CommonTest.hs
@@ -3,6 +3,7 @@ module Main where
 import Test.Tasty
 import qualified CommonTest.Queue as QueueTest
 import qualified CommonTest.RewindQueue as RewindQueueTest
+import qualified CommonTest.RangeSet as RangeSetTest
 
 main :: IO ()
 main = defaultMain tests
@@ -10,4 +11,5 @@ main = defaultMain tests
 tests :: TestTree
 tests = testGroup "Common Tests" [ QueueTest.tests
                                  , RewindQueueTest.tests
+                                 , RangeSetTest.tests
                                  ]

--- a/parsley-core/test/CommonTest/RangeSet.hs
+++ b/parsley-core/test/CommonTest/RangeSet.hs
@@ -33,6 +33,7 @@ instance (Arbitrary a, Enum a, Ord a) => Arbitrary (RangeSet a) where
 
 instance Arbitrary Digit where
   arbitrary = chooseEnum (Zero, Nine)
+  shrink Zero = []
   shrink n = [Zero .. pred n]
 
 tests :: TestTree
@@ -51,7 +52,7 @@ tests = testGroup "RangeSet" [
     testProperty "allLess should find everything strictly less than a value" $ allLessMin @Word,
     testProperty "allMore should find everything strictly more than a value" $ allMoreMax @Word,
     testProperty "union should union" $ uncurry (unionProperty @Int),
-    testProperty "intersection should intersect" $ uncurry (intersectionProperty @Char),
+    testProperty "intersection should intersect" $ uncurry (intersectionProperty @Digit),
     testProperty "difference should differentiate" $ uncurry (differenceProperty @Word)
   ]
 
@@ -130,7 +131,7 @@ unionProperty t1 t2 = not (null t1 && null t2) ==>
          member x (t1 `union` t2))
   .&&. valid (t1 `union` t2)
 
-intersectionProperty :: (Ord a, Enum a, Show a, Bounded a) => RangeSet a -> RangeSet a -> Property
+intersectionProperty :: (Ord a, Enum a, Show a) => RangeSet a -> RangeSet a -> Property
 intersectionProperty t1 t2 = not (null t1 && null t2) ==>
   forAll (elements (elems t1 ++ elems t2)) (\x ->
          (member x t1 && member x t2) === member x (t1 `intersection` t2))

--- a/parsley-core/test/CommonTest/RangeSet.hs
+++ b/parsley-core/test/CommonTest/RangeSet.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE TypeApplications, StandaloneDeriving, DeriveGeneric #-}
+module CommonTest.RangeSet where
+import Test.Tasty (testGroup, TestTree)
+import Test.Tasty.HUnit ( testCase, (@?=) )
+import Test.Tasty.QuickCheck
+  ( listOf,
+    (===),
+    (==>),
+    (.&&.),
+    property,
+    testProperty,
+    elements,
+    forAll,
+    genericShrink,
+    Arbitrary(arbitrary, shrink),
+    Property )
+
+import Prelude hiding (null)
+
+import Parsley.Internal.Common.RangeSet
+import Data.List (nub, sort)
+import GHC.Generics (Generic)
+
+deriving instance Generic (RangeSet a)
+
+instance (Arbitrary a, Enum a, Ord a) => Arbitrary (RangeSet a) where
+  arbitrary = fmap fromList (listOf arbitrary)
+  shrink = filter valid . genericShrink
+
+tests :: TestTree
+tests = testGroup "RangeSet" [
+    testProperty "arbitrary RangeSets should be valid" $ valid @Int,
+    emptyTests,
+    memberTests,
+    insertTests,
+    deleteTests,
+    fromListTests,
+    testProperty "findMin should find the minimum" $ findMinMinimum @Word,
+    testProperty "findMax should find the maximum" $ findMaxMaximum @Int,
+    testProperty "union should union" $ uncurry (unionProperty @Int),
+    testProperty "intersection should intersect" $ uncurry (intersectionProperty @Char),
+    testProperty "difference should differentiate" $ uncurry (differenceProperty @Word)
+  ]
+
+emptyTests :: TestTree
+emptyTests = testGroup "empty should" [
+    testCase "be null" $ null empty @?= True,
+    testCase "have size 0" $ size @Int empty @?= 0
+  ]
+
+-- member, notMember
+memberTests :: TestTree
+memberTests = testGroup "member should" [
+    testCase "work when out of range" $ notMember 5 (fromRanges [(0, 4), (6, 9)]) @?= True,
+    testCase "work when in range" $ member 5 (fromRanges [(0, 9)]) @?= True,
+    testCase "work for exact" $ member 5 (fromRanges [(5, 5)]) @?= True
+  ]
+
+-- insert
+insertTests :: TestTree
+insertTests =
+  let t = fromList [6, 2, 7, 1, 5] -- 1-2, 5-7
+  in testGroup "insert should" [
+    testCase "add something in" $ member 3 (insert 3 t) @?= True,
+    testCase "not affect membership for other items" $ member 4 (insert 3 t) @?= False,
+    testCase "not remove membership" $ member 5 (insert 4 (insert 3 t)) @?= True
+  ]
+
+-- delete
+deleteTests :: TestTree
+deleteTests =
+  let t = fromList [6, 2, 7, 1, 5] -- 1-2, 5-7
+  in testGroup "delete should" [
+    testCase "remove an element" $ notMember 2 (delete 2 t) @?= True,
+    testCase "not affect membership for other items" $ member 1 (delete 2 t) @?= True,
+    testCase "produce valid trees" $ all valid (scanr delete t (sort (elems t))) @?= True
+  ]
+
+fromListTests :: TestTree
+fromListTests = testGroup "fromList" [
+    testProperty "should compose with elems to form (sort . nub)" $ nubSortProperty @Int,
+    testProperty "specifically, case 1" $ nubSortProperty [2,0,3,4,2,6],
+    testProperty "specifically, case 2" $ nubSortProperty [6,7,4,0,6,10,2,12,8]
+  ]
+
+findMinMinimum :: (Ord a, Show a, Enum a) => RangeSet a -> Property
+findMinMinimum t = findMin t === safeMinimum (elems t)
+  where
+    safeMinimum [] = Nothing
+    safeMinimum xs = Just $ minimum xs
+
+findMaxMaximum :: (Ord a, Show a, Enum a) => RangeSet a -> Property
+findMaxMaximum t = findMax t === safeMaximum (elems t)
+  where
+    safeMaximum [] = Nothing
+    safeMaximum xs = Just $ maximum xs
+
+nubSortProperty :: (Enum a, Ord a, Show a) => [a] -> Property
+nubSortProperty xs = sort (nub xs) === elems (fromList xs)
+
+unionProperty :: (Ord a, Enum a, Show a) => RangeSet a -> RangeSet a -> Property
+unionProperty t1 t2 = not (null t1 && null t2) ==>
+  forAll (elements (elems t1 ++ elems t2)) (\x ->
+         member x (t1 `union` t2))
+  .&&. valid (t1 `union` t2)
+
+intersectionProperty :: (Ord a, Enum a, Show a) => RangeSet a -> RangeSet a -> Property
+intersectionProperty t1 t2 = not (null t1 && null t2) ==>
+  forAll (elements (elems t1 ++ elems t2)) (\x ->
+         (member x t1 && member x t2) === member x (t1 `intersection` t2))
+  .&&. valid (t1 `intersection` t2)
+
+differenceProperty :: (Ord a, Enum a, Show a) => RangeSet a -> RangeSet a -> Property
+differenceProperty t1 t2 = not (null t1 && null t2) ==>
+  forAll (elements (elems t1 ++ elems t2)) (\x ->
+         (member x t1 && not (member x t2)) === member x (t1 `difference` t2))
+  .&&. valid (t1 `difference` t2)
+
+{-
+    fromRanges, insertRange
+-}

--- a/parsley-core/test/CommonTest/RangeSet.hs
+++ b/parsley-core/test/CommonTest/RangeSet.hs
@@ -3,7 +3,7 @@ module CommonTest.RangeSet where
 import Test.Tasty (testGroup, TestTree)
 import Test.Tasty.HUnit ( testCase, (@?=) )
 import Test.Tasty.QuickCheck
-  ( listOf,
+  ( listOf, chooseEnum,
     (===),
     (==>),
     (.&&.),
@@ -25,9 +25,15 @@ import Data.Word (Word8)
 
 deriving instance Generic (RangeSet a)
 
+data Digit = Zero | One | Two | Three | Four | Five | Six | Seven | Eight | Nine deriving (Ord, Eq, Enum, Bounded, Show, Generic)
+
 instance (Arbitrary a, Enum a, Ord a) => Arbitrary (RangeSet a) where
   arbitrary = fmap fromList (listOf arbitrary)
   shrink = filter valid . genericShrink
+
+instance Arbitrary Digit where
+  arbitrary = chooseEnum (Zero, Nine)
+  shrink n = [Zero .. pred n]
 
 tests :: TestTree
 tests = testGroup "RangeSet" [
@@ -38,8 +44,8 @@ tests = testGroup "RangeSet" [
     deleteTests,
     fromListTests,
     testProperty "elems and unelems shoudld be disjoint" $ elemUnelemDisjoint @Word8,
-    testProperty "complement . complement = id" $ complementInverse @Word8,
-    testProperty "unelems == elems . complement" $ complementElemsInverse @Word8,
+    testProperty "complement . complement = id" $ complementInverse @Digit,
+    testProperty "unelems == elems . complement" $ complementElemsInverse @Digit,
     testProperty "findMin should find the minimum" $ findMinMinimum @Word,
     testProperty "findMax should find the maximum" $ findMaxMaximum @Int,
     testProperty "union should union" $ uncurry (unionProperty @Int),

--- a/parsley-core/test/CommonTest/RangeSet.hs
+++ b/parsley-core/test/CommonTest/RangeSet.hs
@@ -48,6 +48,8 @@ tests = testGroup "RangeSet" [
     testProperty "unelems == elems . complement" $ complementElemsInverse @Digit,
     testProperty "findMin should find the minimum" $ findMinMinimum @Word,
     testProperty "findMax should find the maximum" $ findMaxMaximum @Int,
+    testProperty "allLess should find everything strictly less than a value" $ allLessMin @Word,
+    testProperty "allMore should find everything strictly more than a value" $ allMoreMax @Word,
     testProperty "union should union" $ uncurry (unionProperty @Int),
     testProperty "intersection should intersect" $ uncurry (intersectionProperty @Char),
     testProperty "difference should differentiate" $ uncurry (differenceProperty @Word)
@@ -139,6 +141,12 @@ differenceProperty t1 t2 = not (null t1 && null t2) ==>
   forAll (elements (elems t1 ++ elems t2)) (\x ->
          (member x t1 && not (member x t2)) === member x (t1 `difference` t2))
   .&&. valid (t1 `difference` t2)
+
+allLessMin :: (Ord a, Enum a, Show a) => RangeSet a -> a -> Property
+allLessMin t x = allLess x t === fromList (filter (< x) (elems t))
+
+allMoreMax :: (Ord a, Enum a, Show a) => RangeSet a -> a -> Property
+allMoreMax t x = allMore x t === fromList (filter (> x) (elems t))
 
 {-
     fromRanges, insertRange

--- a/parsley-core/test/CommonTest/RangeSet.hs
+++ b/parsley-core/test/CommonTest/RangeSet.hs
@@ -53,7 +53,8 @@ memberTests :: TestTree
 memberTests = testGroup "member should" [
     testCase "work when out of range" $ notMember 5 (fromRanges [(0, 4), (6, 9)]) @?= True,
     testCase "work when in range" $ member 5 (fromRanges [(0, 9)]) @?= True,
-    testCase "work for exact" $ member 5 (fromRanges [(5, 5)]) @?= True
+    testCase "work for exact" $ member 5 (fromRanges [(5, 5)]) @?= True,
+    testProperty "perform like elem on elems" $ uncurry (memberElemProperty @Word)
   ]
 
 -- insert
@@ -97,6 +98,9 @@ findMaxMaximum t = findMax t === safeMaximum (elems t)
 
 nubSortProperty :: (Enum a, Ord a, Show a) => [a] -> Property
 nubSortProperty xs = sort (nub xs) === elems (fromList xs)
+
+memberElemProperty :: (Enum a, Ord a, Show a) => a -> RangeSet a -> Property
+memberElemProperty x t = member x t === elem x (elems t)
 
 unionProperty :: (Ord a, Enum a, Show a) => RangeSet a -> RangeSet a -> Property
 unionProperty t1 t2 = not (null t1 && null t2) ==>

--- a/parsley-core/test/CommonTest/RangeSet.hs
+++ b/parsley-core/test/CommonTest/RangeSet.hs
@@ -37,7 +37,7 @@ instance Arbitrary Digit where
 
 tests :: TestTree
 tests = testGroup "RangeSet" [
-    testProperty "arbitrary RangeSets should be valid" $ valid @Int,
+    testProperty "arbitrary RangeSets should be valid" $ valid @Word,
     emptyTests,
     memberTests,
     insertTests,
@@ -130,7 +130,7 @@ unionProperty t1 t2 = not (null t1 && null t2) ==>
          member x (t1 `union` t2))
   .&&. valid (t1 `union` t2)
 
-intersectionProperty :: (Ord a, Enum a, Show a) => RangeSet a -> RangeSet a -> Property
+intersectionProperty :: (Ord a, Enum a, Show a, Bounded a) => RangeSet a -> RangeSet a -> Property
 intersectionProperty t1 t2 = not (null t1 && null t2) ==>
   forAll (elements (elems t1 ++ elems t2)) (\x ->
          (member x t1 && member x t2) === member x (t1 `intersection` t2))

--- a/parsley-core/test/CommonTest/RangeSet.hs
+++ b/parsley-core/test/CommonTest/RangeSet.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TypeApplications, StandaloneDeriving, DeriveGeneric #-}
+{-# LANGUAGE TypeApplications, StandaloneDeriving, DeriveGeneric, MonoLocalBinds #-}
 module CommonTest.RangeSet where
 import Test.Tasty (testGroup, TestTree)
 import Test.Tasty.HUnit ( testCase, (@?=) )

--- a/parsley-core/test/Primitive.hs
+++ b/parsley-core/test/Primitive.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell, UnboxedTuples, ScopedTypeVariables, TypeApplications #-}
+{-# OPTIONS_GHC -ddump-splices #-}
 module Main where
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/parsley-core/test/Primitive.hs
+++ b/parsley-core/test/Primitive.hs
@@ -132,6 +132,12 @@ posAfterNewline = $$(parseMocked Parsers.posAfterNewline  [||Parsers.posAfterNew
 posAfterTab :: String -> Maybe ((Int, Int), (Int, Int))
 posAfterTab = $$(parseMocked Parsers.posAfterTab  [||Parsers.posAfterTab||])
 
+posAfterLookahead :: String -> Maybe ((Int, Int), (Int, Int))
+posAfterLookahead = $$(parseMocked Parsers.posAfterLookahead [||Parsers.posAfterLookahead||])
+
+posAfterNotFollowedBy :: String -> Maybe ((Int, Int), (Int, Int))
+posAfterNotFollowedBy = $$(parseMocked Parsers.posAfterNotFollowedBy [||Parsers.posAfterNotFollowedBy||])
+
 positionTests :: TestTree
 positionTests = testGroup "position combinators should"
   [ testCase "start at line 1" $ lineStarts1 "" @?= Just 1
@@ -139,4 +145,6 @@ positionTests = testGroup "position combinators should"
   , testCase "advance by 1 column only after regular character" $ posAfterA "a" @?= Just (1, 2)
   , testCase "advance by 1 line and reset column after newline" $ posAfterNewline "a\n\n" @?= Just ((2, 1), (3, 1))
   , testCase "advance to nearest tab boundary on tab" $ posAfterTab "\ta\t" @?= Just ((1, 5), (1, 9))
+  , testCase "work with lookahead" $ posAfterLookahead "\t" @?= Just ((1, 1), (1, 5))
+  , testCase "work with notFollowedBy" $ posAfterNotFollowedBy "\n" @?= Just ((1, 1), (2, 1))
   ]

--- a/parsley-core/test/Primitive/Parsers.hs
+++ b/parsley-core/test/Primitive/Parsers.hs
@@ -3,13 +3,14 @@ module Primitive.Parsers where
 
 import Prelude hiding (pure, (<*>), (*>), (<*))
 import Data.Char (isDigit)
-import Parsley.Internal (Parser, Defunc(EMPTY, LIFTED, EQ_H, CONS, LAM_S), makeQ, pure, satisfy, (*>), (<*), (<|>), (<*>), satisfy, lookAhead, line, col)
+import Parsley.Internal (Parser, Defunc(EMPTY, LIFTED, RANGES, CONS), makeQ, pure, satisfy, (*>), (<*), (<|>), (<*>), satisfy, lookAhead, notFollowedBy, line, col)
+import Text.ParserCombinators.ReadP (look)
 
 char :: Char -> Parser Char
-char c = satisfy (EQ_H (LIFTED c))
+char c = satisfy (RANGES True [(c, c)])
 
 item :: Parser Char
-item = satisfy (LAM_S (const (LIFTED True)))
+item = satisfy (RANGES False [])
 
 pure7 :: Parser Int
 pure7 = pure (LIFTED 7)
@@ -48,3 +49,9 @@ posAfterNewline = (char 'a' *> char '\n' *> pos) <~> (char '\n' *> pos)
 
 posAfterTab :: Parser ((Int, Int), (Int, Int))
 posAfterTab = (char '\t' *> pos) <~> (char 'a' *> char '\t' *> pos)
+
+posAfterLookahead :: Parser ((Int, Int), (Int, Int))
+posAfterLookahead = lookAhead (char '\t') *> pos <~> (item *> pos)
+
+posAfterNotFollowedBy :: Parser ((Int, Int), (Int, Int))
+posAfterNotFollowedBy = notFollowedBy (char '\t') *> pos <~> (item *> pos)

--- a/parsley/parsley.cabal
+++ b/parsley/parsley.cabal
@@ -126,7 +126,6 @@ common benchmark-common
   build-depends:       base >=4.10 && <5,
                        parsley,
                        parsley-garnish,
-                       --criterion >=1.5 && <1.6,
                        gauge,
                        deepseq,
                        template-haskell,


### PR DESCRIPTION
By incorporating `CharPred`, a specialised layer for the defunctionalisation of character predicates, we can simplify position updates as well as optimising (or removing) character predicates when it can be established that it already holds true, or not.

As a consequence, code like `lookAhead (string "abc") *> string "abc"` will actually be as efficient as `string "abc"`: the compiler is able to deduce that the next three characters after the lookahead rolls back are a, b, and c, so it can resolve the remaining parser at compile-time!

This also introduces the `RangeSet` abstraction, as well as fusing position updates into a single update widget.