### PR TITLE
Remove goal type

### DIFF
--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine.hs
@@ -40,7 +40,7 @@ for a parser.
 
 @since 0.1.0.0
 -}
-eval :: forall input a. (Input input, Trace) => Code input -> (LetBinding input a a, DMap MVar (LetBinding input a)) -> Code (Maybe a)
+eval :: (Input input, Trace) => Code input -> (LetBinding input a, DMap MVar (LetBinding input)) -> Code (Maybe a)
 eval input (toplevel, bindings) = Eval.eval (prepare input) toplevel bindings
 
 {-|

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Ops.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Ops.hs
@@ -227,7 +227,7 @@ which takes the captured offset as the first argument.
 @since 1.2.0.0
 -}
 buildHandler :: Γ s o xs n r a                                  -- ^ State to execute the handler with.
-             -> (Γ s o (o : xs) n r a -> Code (ST s (Maybe a))) -- ^ Partial parser accepting the modified state.
+             -> (Γ s o (o : xs) n r a -> Code (ST s (Maybe a))) -- ^ Partial parserccepting the modified state.
              -> Word                                            -- ^ The unique identifier for the offset on failure.
              -> StaHandlerBuilder s o a
 buildHandler γ h u c = fromStaHandler# $ \inp -> h (γ {operands = Op (INPUT c) (operands γ), input = toInput u inp})
@@ -382,9 +382,9 @@ into the `Ctx`.
 -}
 setupJoinPoint :: forall s o xs n r a x. JoinBuilder o
                => ΦVar x                     -- ^ The name of the binding.
-               -> Machine s o (x : xs) n r a -- ^ The definition of the binding.
-               -> Machine s o xs n r a       -- ^ The scope within which the binding is valid.
-               -> MachineMonad s o xs n r a
+               -> Machine s o a (x : xs) n r -- ^ The definition of the binding.
+               -> Machine s o a xs n r       -- ^ The scope within which the binding is valid.
+               -> MachineMonad s o a xs n r
 setupJoinPoint φ (Machine k) mx = freshUnique $ \u ->
     liftM2 (\mk ctx γ ->
       setupJoinPoint# @o
@@ -404,7 +404,7 @@ the loop consumed input in its final iteration.
 bindIterAlways :: forall s o a. RecBuilder o
                => Ctx s o a                  -- ^ The context to keep the binding
                -> MVar Void                  -- ^ The name of the binding.
-               -> Machine s o '[] One Void a -- ^ The body of the loop.
+               -> Machine s o a '[] One Void -- ^ The body of the loop.
                -> Bool                       -- ^ Does loop exit require a binding?
                -> StaHandlerBuilder s o a    -- ^ What to do after the loop exits (by failing)
                -> Input o                    -- ^ The initial offset to provide to the loop
@@ -426,7 +426,7 @@ the same way as `bindSameHandler`.
 bindIterSame :: forall s o a. (RecBuilder o, HandlerOps o, PositionOps (Rep o))
              => Ctx s o a                  -- ^ The context to store the binding in.
              -> MVar Void                  -- ^ The name of the binding.
-             -> Machine s o '[] One Void a -- ^ The loop body.
+             -> Machine s o a '[] One Void -- ^ The loop body.
              -> Bool                       -- ^ Is a binding required for the matching handler?
              -> StaHandler s o a           -- ^ The handler when input is the same.
              -> Bool                       -- ^ Is a binding required for the differing handler?
@@ -457,7 +457,7 @@ buildRec :: forall rs s o a r. RecBuilder o
          => MVar r                  -- ^ The name of the binding.
          -> Regs rs                 -- ^ The registered required by the binding.
          -> Ctx s o a               -- ^ The context to re-insert the register-less binding
-         -> Machine s o '[] One r a -- ^ The body of the binding.
+         -> Machine s o a '[] One r -- ^ The body of the binding.
          -> Metadata                -- ^ The metadata associated with the binding
          -> DynFunc rs s o a r
 buildRec μ rs ctx k meta =

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Types.hs
@@ -31,14 +31,14 @@ The monad stack used to evaluate a parser machine, see `run`.
 
 @since 1.4.0.0
 -}
-type MachineMonad s o xs n r a = Reader (Ctx s o a) (Γ s o xs n r a -> Code (ST s (Maybe a)))
+type MachineMonad s o a xs n r = Reader (Ctx s o a) (Γ s o xs n r a -> Code (ST s (Maybe a)))
 
 {-|
 Wraps up the `MachineMonad` type so that it can serve as the carrier of `Parsley.Internal.Common.Indexed.cata4`.
 
 @since 1.4.0.0
 -}
-newtype Machine s o xs n r a = Machine { getMachine :: MachineMonad s o xs n r a }
+newtype Machine s o a xs n r = Machine { getMachine :: MachineMonad s o a xs n r }
 
 {-|
 Used to execute the evaluator for a parser machine, resulting in the final code
@@ -46,7 +46,7 @@ to be returned back to the User API.
 
 @since 1.4.0.0
 -}
-run :: Machine s o xs n r a  -- ^ The action that will generate the final code.
+run :: Machine s o a xs n r  -- ^ The action that will generate the final code.
     -> Γ s o xs n r a        -- ^ The informaton that is threaded through the parsing machinery, which appears in some form in the generated code.
     -> Ctx s o a             -- ^ Static information used in the code generation process, but not in the generated code.
     -> Code (ST s (Maybe a)) -- ^ The code that represents this parser (after having been given an input).

--- a/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine.hs
+++ b/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine.hs
@@ -35,7 +35,7 @@ import Parsley.Internal.Trace                        (Trace)
 import qualified Data.ByteString.Lazy as Lazy (ByteString)
 import qualified Parsley.Internal.Backend.Machine.Eval as Eval (eval)
 
-eval :: forall input a. (Input input, Trace) => Code input -> (LetBinding (Rep input) a a, DMap MVar (LetBinding (Rep input) a)) -> Code (Maybe a)
+eval :: (Input input, Trace) => Code input -> (LetBinding (Rep input) a, DMap MVar (LetBinding (Rep input))) -> Code (Maybe a)
 eval input (toplevel, bindings) = Eval.eval (prepare input) toplevel bindings
 
 class (InputPrep input, Ops (Rep input)) => Input input

--- a/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Ops.hs
+++ b/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Ops.hs
@@ -154,16 +154,16 @@ inputInstances(deriveReturnOps)
 
 {- Builder Operations -}
 class BoxOps o => JoinBuilder o where
-  setupJoinPoint :: ΦVar x -> Machine s o (x : xs) n r a -> Machine s o xs n r a -> MachineMonad s o xs n r a
+  setupJoinPoint :: ΦVar x -> Machine s o a (x : xs) n r -> Machine s o a xs n r -> MachineMonad s o a xs n r
 
 class BoxOps o => RecBuilder o where
   buildIter :: ReturnOps o
-            => Ctx s o a -> MVar Void -> Machine s o '[] One Void a
+            => Ctx s o a -> MVar Void -> Machine s o a '[] One Void
             -> (Code o -> (Code Int, Code Int) -> Code (Handler s o a)) -> Code o -> (Code Int, Code Int) -> Code (ST s (Maybe a))
   buildRec  :: MVar r
             -> Regs rs
             -> Ctx s o a
-            -> Machine s o '[] One r a
+            -> Machine s o a '[] One r
             -> Code (Func rs s o a r)
 
 #define deriveJoinBuilder(_o)                                                             \

--- a/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Types/State.hs
+++ b/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/Types/State.hs
@@ -36,7 +36,7 @@ type HandlerStack n s o a = Vec n (Code (Handler s o a))
 type Handler s o a = Unboxed o -> Int -> Int -> ST s (Maybe a)
 type Cont s o a x = x -> Unboxed o -> Int -> Int -> ST s (Maybe a)
 type Subroutine s o a x = Cont s o a x -> Unboxed o -> Int -> Int -> Handler s o a -> ST s (Maybe a)
-type MachineMonad s o xs n r a = Reader (Ctx s o a) (Γ s o xs n r a -> Code (ST s (Maybe a)))
+type MachineMonad s o a xs n r = Reader (Ctx s o a) (Γ s o xs n r a -> Code (ST s (Maybe a)))
 
 type family Func (rs :: [Type]) s o a x where
   Func '[] s o a x      = Subroutine s o a x
@@ -48,9 +48,9 @@ qSubroutine :: Code (Func rs s o a x) -> Regs rs -> Metadata -> QSubroutine s o 
 qSubroutine body frees _ = QSubroutine body frees
 
 newtype QJoin s o a x = QJoin { unwrapJoin :: Code (Cont s o a x) }
-newtype Machine s o xs n r a = Machine { getMachine :: MachineMonad s o xs n r a }
+newtype Machine s o a xs n r = Machine { getMachine :: MachineMonad s o a xs n r }
 
-run :: Machine s o xs n r a -> Γ s o xs n r a -> Ctx s o a -> Code (ST s (Maybe a))
+run :: Machine s o a xs n r -> Γ s o xs n r a -> Ctx s o a -> Code (ST s (Maybe a))
 run = flip . runReader . getMachine
 
 data OpStack xs where

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/Analysis/Coins.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/Analysis/Coins.hs
@@ -16,23 +16,23 @@ module Parsley.Internal.Backend.Analysis.Coins (coinsNeeded, reclaimable) where
 
 import Data.Bifunctor                   (first)
 import Parsley.Internal.Backend.Machine (Instr(..), MetaInstr(..), Handler(..), Coins, plus1, minCoins, maxCoins, zero, minus, plusNotReclaim, willConsume)
-import Parsley.Internal.Common.Indexed  (cata4, Fix4, Const4(..))
+import Parsley.Internal.Common.Indexed  (cata3, Fix3, Const3(..))
 
 {-|
 Calculate the number of tokens that will be consumed by a given machine.
 
 @since 1.5.0.0
 -}
-coinsNeeded :: Fix4 (Instr o) xs n r a -> Coins
-coinsNeeded = fst . getConst4 . cata4 (Const4 . alg True)
+coinsNeeded :: Fix3 (Instr o) xs n r -> Coins
+coinsNeeded = fst . getConst3 . cata3 (Const3 . alg True)
 
 {-|
 Calculate the number of tokens can be reclaimed by a lookAhead
 
 @since 1.7.2.0
 -}
-reclaimable :: Fix4 (Instr o) xs n r a -> Coins
-reclaimable = fst . getConst4 . cata4 (Const4 . alg False)
+reclaimable :: Fix3 (Instr o) xs n r -> Coins
+reclaimable = fst . getConst3 . cata3 (Const3 . alg False)
 
 bilift2 :: (a -> b -> c) -> (x -> y -> z) -> (a, x) -> (b, y) -> (c, z)
 bilift2 f g (x1, y1) (x2, y2) = (f x1 x2, g y1 y2)
@@ -45,40 +45,40 @@ algCatch (k1, _) (k2, _) = (minCoins k1 k2, False)
 -- Bool represents if an empty is found in a branch (of a Catch)
 -- This helps to get rid of `min` being used for `Try` where min is always 0
 -- (The input is needed to /succeed/, so if one branch is doomed to fail it doesn't care about coins)
-alg :: Bool -> Instr o (Const4 (Coins, Bool)) xs n r a -> (Coins, Bool)
+alg :: Bool -> Instr o (Const3 (Coins, Bool)) xs n r -> (Coins, Bool)
 alg _     Ret                                     = (zero, False)
-alg _     (Push _ k)                              = getConst4 k -- was const False on the second parameter, I think that's probably right but a bit presumptive
-alg _     (Pop k)                                 = getConst4 k
-alg _     (Lift2 _ k)                             = getConst4 k
-alg _     (Sat _ (Const4 k))                      = first plus1 k
-alg _     (Call _ (Const4 k))                     = first (const zero) k
+alg _     (Push _ k)                              = getConst3 k -- was const False on the second parameter, I think that's probably right but a bit presumptive
+alg _     (Pop k)                                 = getConst3 k
+alg _     (Lift2 _ k)                             = getConst3 k
+alg _     (Sat _ (Const3 k))                      = first plus1 k
+alg _     (Call _ (Const3 k))                     = first (const zero) k
 alg _     (Jump _)                                = (zero, False)
 alg _     Empt                                    = (zero, True)
-alg _     (Commit k)                              = getConst4 k
-alg _     (Catch k h)                             = algCatch (getConst4 k) (algHandler h)
-alg _     (Tell k)                                = getConst4 k
-alg _     (Seek k)                                = getConst4 k
-alg _     (Case p q)                              = algCatch (getConst4 p) (getConst4 q)
-alg _     (Choices _ ks def)                      = foldr (algCatch . getConst4) (getConst4 def) ks
+alg _     (Commit k)                              = getConst3 k
+alg _     (Catch k h)                             = algCatch (getConst3 k) (algHandler h)
+alg _     (Tell k)                                = getConst3 k
+alg _     (Seek k)                                = getConst3 k
+alg _     (Case p q)                              = algCatch (getConst3 p) (getConst3 q)
+alg _     (Choices _ ks def)                      = foldr (algCatch . getConst3) (getConst3 def) ks
 alg _     (Iter _ _ h)                            = first (const zero) (algHandler h)
 alg _     (Join _)                                = (zero, False)
-alg _     (MkJoin _ (Const4 b) (Const4 k))        = bilift2 (flip plusNotReclaim . willConsume) (||) b k
-alg _     (Swap k)                                = getConst4 k
-alg _     (Dup k)                                 = getConst4 k
-alg _     (Make _ _ k)                            = getConst4 k
-alg _     (Get _ _ k)                             = getConst4 k
-alg _     (Put _ _ (Const4 k))                    = first (const zero) k
-alg _     (SelectPos _ k)                         = getConst4 k
-alg _     (LogEnter _ k)                          = getConst4 k
-alg _     (LogExit _ k)                           = getConst4 k
-alg _     (MetaInstr (AddCoins _) (Const4 k))     = k
-alg _     (MetaInstr (RefundCoins n) (Const4 k))  = first (maxCoins zero . (`minus` n)) k -- These were refunded, so deduct
+alg _     (MkJoin _ (Const3 b) (Const3 k))        = bilift2 (flip plusNotReclaim . willConsume) (||) b k
+alg _     (Swap k)                                = getConst3 k
+alg _     (Dup k)                                 = getConst3 k
+alg _     (Make _ _ k)                            = getConst3 k
+alg _     (Get _ _ k)                             = getConst3 k
+alg _     (Put _ _ (Const3 k))                    = first (const zero) k
+alg _     (SelectPos _ k)                         = getConst3 k
+alg _     (LogEnter _ k)                          = getConst3 k
+alg _     (LogExit _ k)                           = getConst3 k
+alg _     (MetaInstr (AddCoins _) (Const3 k))     = k
+alg _     (MetaInstr (RefundCoins n) (Const3 k))  = first (maxCoins zero . (`minus` n)) k -- These were refunded, so deduct
 alg _     (MetaInstr (DrainCoins n) _)            = (n, False)                            -- Used to be `second (const False) k`, but these should be additive?
 alg _     (MetaInstr (GiveBursary n) _)           = (n, False)                            -- We know that `n` is the required for `k`
-alg _     (MetaInstr (PrefetchChar _) (Const4 k)) = k
-alg True  (MetaInstr BlockCoins (Const4 k))       = first (const zero) k
-alg False (MetaInstr BlockCoins (Const4 k))       = k
+alg _     (MetaInstr (PrefetchChar _) (Const3 k)) = k
+alg True  (MetaInstr BlockCoins (Const3 k))       = first (const zero) k
+alg False (MetaInstr BlockCoins (Const3 k))       = k
 
-algHandler :: Handler o (Const4 (Coins, Bool)) xs n r a -> (Coins, Bool)
-algHandler (Same _ yes _ no) = algCatch (getConst4 yes) (getConst4 no)
-algHandler (Always _ k) = getConst4 k
+algHandler :: Handler o (Const3 (Coins, Bool)) xs n r -> (Coins, Bool)
+algHandler (Same _ yes _ no) = algCatch (getConst3 yes) (getConst3 no)
+algHandler (Always _ k) = getConst3 k

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/Analysis/Inliner.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/Analysis/Inliner.hs
@@ -14,7 +14,7 @@ module Parsley.Internal.Backend.Analysis.Inliner (shouldInline) where
 
 import Data.Ratio                       ((%))
 import Parsley.Internal.Backend.Machine (Instr(..), Handler(..), Access(Hard, Soft))
-import Parsley.Internal.Common.Indexed  (cata4, Fix4, Nat)
+import Parsley.Internal.Common.Indexed  (cata3, Fix3, Nat)
 
 inlineThreshold :: Rational
 inlineThreshold = 13 % 10
@@ -25,12 +25,12 @@ entry to a machine are actually used in the computation.
 
 @since 1.7.0.0
 -}
-shouldInline :: Fix4 (Instr o) xs n r a -> Bool
-shouldInline = (< inlineThreshold) . getWeight . cata4 (InlineWeight . alg)
+shouldInline :: Fix3 (Instr o) xs n r -> Bool
+shouldInline = (< inlineThreshold) . getWeight . cata3 (InlineWeight . alg)
 
-newtype InlineWeight xs (n :: Nat) r a = InlineWeight { getWeight :: Rational }
+newtype InlineWeight xs (n :: Nat) r = InlineWeight { getWeight :: Rational }
 
-alg :: Instr o InlineWeight xs n r a -> Rational
+alg :: Instr o InlineWeight xs n r -> Rational
 alg Ret                = 0
 alg (Push _ k)         = 0 + getWeight k
 alg (Pop k)            = 0 + getWeight k
@@ -61,10 +61,10 @@ alg (LogEnter _ k)     = 1 % 4 + getWeight k
 alg (LogExit _ k)      = 1 % 4 + getWeight k
 alg (MetaInstr _ k)    = 0 + getWeight k
 
-algHandler :: Handler o InlineWeight xs n r a -> Rational
+algHandler :: Handler o InlineWeight xs n r -> Rational
 algHandler (Always _ h) = getWeight h
 algHandler (Same _ y _ n) = getWeight y + getWeight n
 
-handlerInlined :: Handler o k xs n r a -> Bool
+handlerInlined :: Handler o k xs n r -> Bool
 handlerInlined (Always True _) = True
 handlerInlined _               = False

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/Analysis/Relevancy.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/Analysis/Relevancy.hs
@@ -18,7 +18,7 @@ module Parsley.Internal.Backend.Analysis.Relevancy (relevancy, Length) where
 
 import Data.Kind                        (Type)
 import Parsley.Internal.Backend.Machine (Instr(..), Handler(..))
-import Parsley.Internal.Common.Indexed  (cata4, Fix4)
+import Parsley.Internal.Common.Indexed  (cata3, Fix3)
 import Parsley.Internal.Common.Vec      (Vec(..), Nat(..), SNat(..), SingNat(..), zipWithVec, replicateVec)
 
 {-|
@@ -27,8 +27,8 @@ entry to a machine are actually used in the computation.
 
 @since 1.5.0.0
 -}
-relevancy :: SingNat (Length xs) => Fix4 (Instr o) xs n r a -> Vec (Length xs) Bool
-relevancy = ($ sing) . getStack . cata4 (RelevancyStack . alg)
+relevancy :: SingNat (Length xs) => Fix3 (Instr o) xs n r -> Vec (Length xs) Bool
+relevancy = ($ sing) . getStack . cata3 (RelevancyStack . alg)
 
 {-|
 Computes the length of a type-level list. Used to index a `Vec`.
@@ -39,13 +39,13 @@ type family Length (xs :: [Type]) :: Nat where
   Length '[] = Zero
   Length (_ : xs) = Succ (Length xs)
 
-newtype RelevancyStack xs (n :: Nat) r a = RelevancyStack { getStack :: SNat (Length xs) -> Vec (Length xs) Bool }
+newtype RelevancyStack xs (n :: Nat) r = RelevancyStack { getStack :: SNat (Length xs) -> Vec (Length xs) Bool }
 
 zipRelevancy :: Vec n Bool -> Vec n Bool -> Vec n Bool
 zipRelevancy = zipWithVec (||)
 
 -- This algorithm is over-approximating: join and ret aren't _always_ relevant
-alg :: Instr o RelevancyStack xs n r a -> SNat (Length xs) -> Vec (Length xs) Bool
+alg :: Instr o RelevancyStack xs n r -> SNat (Length xs) -> Vec (Length xs) Bool
 alg Ret                _         = VCons True VNil
 alg (Push _ k)         n         = let VCons _ xs = getStack k (SSucc n) in xs
 alg (Pop k)            (SSucc n) = VCons False (getStack k n)
@@ -73,6 +73,6 @@ alg (LogEnter _ k)     n         = getStack k n
 alg (LogExit _ k)      n         = getStack k n
 alg (MetaInstr _ k)    n         = getStack k n
 
-algHandler :: Handler o RelevancyStack xs n r a -> SNat (Length xs) -> Vec (Length xs) Bool
+algHandler :: Handler o RelevancyStack xs n r -> SNat (Length xs) -> Vec (Length xs) Bool
 algHandler (Same _ yes _ no) (SSucc n) = VCons True (let VCons _ xs = zipRelevancy (VCons False (getStack yes n)) (getStack no (SSucc n)) in xs)
 algHandler (Always _ k) n = getStack k n

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/CodeGenerator.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/CodeGenerator.hs
@@ -23,7 +23,7 @@ import Parsley.Internal.Backend.Machine    (user, LetBinding, makeLetBinding, ne
                                             IMVar, IΦVar, MVar(..), ΦVar(..), SomeΣVar)
 import Parsley.Internal.Backend.Analysis   (coinsNeeded, shouldInline, reclaimable)
 import Parsley.Internal.Common.Fresh       (VFreshT, VFresh, evalFreshT, evalFresh, construct, MonadFresh(..), mapVFreshT)
-import Parsley.Internal.Common.Indexed     (Fix, Fix4(In4), Cofree(..), Nat(..), imap, histo, extract, (|>))
+import Parsley.Internal.Common.Indexed     (Fix, Fix3(In3), Cofree(..), Nat(..), imap, histo, extract, (|>))
 import Parsley.Internal.Core.CombinatorAST (Combinator(..), MetaCombinator(..))
 import Parsley.Internal.Core.Defunc        (pattern UNIT)
 import Parsley.Internal.Trace              (Trace(trace))
@@ -34,8 +34,8 @@ type CodeGenStack a = VFreshT IΦVar (VFresh IMVar) a
 runCodeGenStack :: CodeGenStack a -> IMVar -> IΦVar -> a
 runCodeGenStack m μ0 φ0 = evalFresh (evalFreshT m φ0) μ0
 
-newtype CodeGen o a x =
-  CodeGen {runCodeGen :: forall xs n r. Fix4 (Instr o) (x : xs) (Succ n) r a -> CodeGenStack (Fix4 (Instr o) xs (Succ n) r a)}
+newtype CodeGen o x =
+  CodeGen {runCodeGen :: forall xs n r. Fix3 (Instr o) (x : xs) (Succ n) r -> CodeGenStack (Fix3 (Instr o) xs (Succ n) r)}
 
 {-|
 Translates a parser represented with combinators into its machine representation.
@@ -48,16 +48,16 @@ codeGen :: Trace
         -> Fix Combinator x -- ^ The definition of the parser.
         -> Set SomeΣVar     -- ^ The free registers it requires to run.
         -> IMVar            -- ^ The binding identifier to start name generation from.
-        -> LetBinding o a x
+        -> LetBinding o x
 codeGen letBound p rs μ0 = trace ("GENERATING " ++ name ++ ": " ++ show p ++ "\nMACHINE: " ++ show (elems rs) ++ " => " ++ show m) $ makeLetBinding m rs newMeta
   where
     name = maybe "TOP LEVEL" show letBound
     m = finalise (histo alg p)
-    alg :: Combinator (Cofree Combinator (CodeGen o a)) x -> CodeGen o a x
+    alg :: Combinator (Cofree Combinator (CodeGen o)) x -> CodeGen o x
     alg = deep |> (\x -> CodeGen (shallow (imap extract x)))
     -- It is never safe to add coins to the top of a binding
     -- This is because we don't know the characteristics of the caller (even the top-level!)
-    finalise cg = runCodeGenStack (runCodeGen cg (In4 Ret)) μ0 0
+    finalise cg = runCodeGenStack (runCodeGen cg (In3 Ret)) μ0 0
 
 pattern (:<$>:) :: Core.Defunc (a -> b) -> Cofree Combinator k a -> Combinator (Cofree Combinator k) b
 pattern f :<$>: p <- (_ :< Pure f) :<*>: p
@@ -68,19 +68,19 @@ pattern TryOrElse p q <- (_ :< Try (p :< _)) :<|>: (q :< _)
 
 -- it would be nice to generate `yesSame` handler bindings for Try, perhaps a special flag?
 -- relevancy analysis might help too I guess, for a more general one?
-rollbackHandler :: Handler o (Fix4 (Instr o)) (o : xs) (Succ n) r a
-rollbackHandler = Always False (In4 (Seek (In4 Empt)))
+rollbackHandler :: Handler o (Fix3 (Instr o)) (o : xs) (Succ n) r
+rollbackHandler = Always False (In3 (Seek (In3 Empt)))
 
-parsecHandler :: Fix4 (Instr o) xs (Succ n) r a -> Handler o (Fix4 (Instr o)) (o : xs) (Succ n) r a
-parsecHandler k = Same (not (shouldInline k)) k False (In4 Empt)
+parsecHandler :: Fix3 (Instr o) xs (Succ n) r -> Handler o (Fix3 (Instr o)) (o : xs) (Succ n) r
+parsecHandler k = Same (not (shouldInline k)) k False (In3 Empt)
 
-recoverHandler :: Fix4 (Instr o) xs n r a -> Handler o (Fix4 (Instr o)) (o : xs) n r a
-recoverHandler = Always . not . shouldInline <*> In4 . Seek
+recoverHandler :: Fix3 (Instr o) xs n r -> Handler o (Fix3 (Instr o)) (o : xs) n r
+recoverHandler = Always . not . shouldInline <*> In3 . Seek
 
-altNoCutCompile :: Trace => CodeGen o a y -> CodeGen o a x
-                -> (forall n xs r. Fix4 (Instr o) xs (Succ n) r a -> Handler o (Fix4 (Instr o)) (o : xs) (Succ n) r a)
-                -> (forall n xs r. Fix4 (Instr o) (x : xs) n r a  -> Fix4 (Instr o) (y : xs) n r a)
-                -> Fix4 (Instr o) (x : xs) (Succ n) r a -> CodeGenStack (Fix4 (Instr o) xs (Succ n) r a)
+altNoCutCompile :: Trace => CodeGen o y -> CodeGen o x
+                -> (forall n xs r. Fix3 (Instr o) xs (Succ n) r -> Handler o (Fix3 (Instr o)) (o : xs) (Succ n) r)
+                -> (forall n xs r. Fix3 (Instr o) (x : xs) n r  -> Fix3 (Instr o) (y : xs) n r)
+                -> Fix3 (Instr o) (x : xs) (Succ n) r -> CodeGenStack (Fix3 (Instr o) xs (Succ n) r)
 altNoCutCompile p q handler post m =
   do (binder, φ) <- makeΦ m
      pc <- freshΦ (runCodeGen p (deadCommitOptimisation (post φ)))
@@ -89,87 +89,87 @@ altNoCutCompile p q handler post m =
      let nq = coinsNeeded qc
      let dp = np `minus` minCoins np nq
      let dq = nq `minus` minCoins np nq
-     return $! binder (In4 (Catch (addCoins dp pc) (handler (addCoins dq qc))))
+     return $! binder (In3 (Catch (addCoins dp pc) (handler (addCoins dq qc))))
 
-loopCompile :: CodeGen o a () -> CodeGen o a x
-            -> (forall n xs r. Fix4 (Instr o) xs (Succ n) r a -> Fix4 (Instr o) xs (Succ n) r a)
-            -> (forall n xs r. Fix4 (Instr o) xs (Succ n) r a -> Fix4 (Instr o) xs (Succ n) r a)
-            -> Fix4 (Instr o) (x : xs) (Succ n) r a -> CodeGenStack (Fix4 (Instr o) xs (Succ n) r a)
+loopCompile :: CodeGen o () -> CodeGen o x
+            -> (forall n xs r. Fix3 (Instr o) xs (Succ n) r -> Fix3 (Instr o) xs (Succ n) r)
+            -> (forall n xs r. Fix3 (Instr o) xs (Succ n) r -> Fix3 (Instr o) xs (Succ n) r)
+            -> Fix3 (Instr o) (x : xs) (Succ n) r -> CodeGenStack (Fix3 (Instr o) xs (Succ n) r)
 loopCompile body exit prebody preExit m =
   do μ <- askM
-     bodyc <- freshM (runCodeGen body (In4 (Pop (In4 (Jump μ)))))
+     bodyc <- freshM (runCodeGen body (In3 (Pop (In3 (Jump μ)))))
      exitc <- freshM (runCodeGen exit m)
-     return $! In4 (Iter μ (prebody bodyc) (parsecHandler (preExit exitc)))
+     return $! In3 (Iter μ (prebody bodyc) (parsecHandler (preExit exitc)))
 
-deep :: Trace => Combinator (Cofree Combinator (CodeGen o a)) x -> Maybe (CodeGen o a x)
-deep (f :<$>: (p :< _)) = Just $ CodeGen $ \m -> runCodeGen p (In4 (_Fmap (user f) m))
+deep :: Trace => Combinator (Cofree Combinator (CodeGen o)) x -> Maybe (CodeGen o x)
+deep (f :<$>: (p :< _)) = Just $ CodeGen $ \m -> runCodeGen p (In3 (_Fmap (user f) m))
 deep (TryOrElse p q) = Just $ CodeGen $ altNoCutCompile p q recoverHandler id
-deep ((_ :< (Try (p :< _) :$>: x)) :<|>: (q :< _)) = Just $ CodeGen $ altNoCutCompile p q recoverHandler (In4 . Pop . In4 . Push (user x))
-deep ((_ :< (f :<$>: (_ :< Try (p :< _)))) :<|>: (q :< _)) = Just $ CodeGen $ altNoCutCompile p q recoverHandler (In4 . _Fmap (user f))
+deep ((_ :< (Try (p :< _) :$>: x)) :<|>: (q :< _)) = Just $ CodeGen $ altNoCutCompile p q recoverHandler (In3 . Pop . In3 . Push (user x))
+deep ((_ :< (f :<$>: (_ :< Try (p :< _)))) :<|>: (q :< _)) = Just $ CodeGen $ altNoCutCompile p q recoverHandler (In3 . _Fmap (user f))
 deep (MetaCombinator RequiresCut (_ :< ((p :< _) :<|>: (q :< _)))) = Just $ CodeGen $ \m ->
   do (binder, φ) <- makeΦ m
      pc <- freshΦ (runCodeGen p (deadCommitOptimisation φ))
      qc <- freshΦ (runCodeGen q φ)
-     return $! binder (In4 (Catch pc (parsecHandler qc)))
+     return $! binder (In3 (Catch pc (parsecHandler qc)))
 deep (MetaCombinator RequiresCut (_ :< Loop (body :< _) (exit :< _))) = Just $ CodeGen $ loopCompile body exit id addCoinsNeeded
 deep (MetaCombinator Cut (_ :< Loop (body :< _) (exit :< _))) = Just $ CodeGen $ loopCompile body exit addCoinsNeeded addCoinsNeeded
 deep _ = Nothing
 
-addCoinsNeeded :: Fix4 (Instr o) xs (Succ n) r a -> Fix4 (Instr o) xs (Succ n) r a
+addCoinsNeeded :: Fix3 (Instr o) xs (Succ n) r -> Fix3 (Instr o) xs (Succ n) r
 addCoinsNeeded = coinsNeeded >>= addCoins
 
-shallow :: Trace => Combinator (CodeGen o a) x -> Fix4 (Instr o) (x : xs) (Succ n) r a -> CodeGenStack (Fix4 (Instr o) xs (Succ n) r a)
-shallow (Pure x)      m = do return $! In4 (Push (user x) m)
-shallow (Satisfy p)   m = do return $! In4 (Sat p m)
-shallow (pf :<*>: px) m = do pxc <- runCodeGen px (In4 (_App m)); runCodeGen pf pxc
-shallow (p :*>: q)    m = do qc <- runCodeGen q m; runCodeGen p (In4 (Pop qc))
-shallow (p :<*: q)    m = do qc <- runCodeGen q (In4 (Pop m)); runCodeGen p qc
-shallow Empty         _ = do return $! In4 Empt
+shallow :: Trace => Combinator (CodeGen o) x -> Fix3 (Instr o) (x : xs) (Succ n) r -> CodeGenStack (Fix3 (Instr o) xs (Succ n) r)
+shallow (Pure x)      m = do return $! In3 (Push (user x) m)
+shallow (Satisfy p)   m = do return $! In3 (Sat p m)
+shallow (pf :<*>: px) m = do pxc <- runCodeGen px (In3 (_App m)); runCodeGen pf pxc
+shallow (p :*>: q)    m = do qc <- runCodeGen q m; runCodeGen p (In3 (Pop qc))
+shallow (p :<*: q)    m = do qc <- runCodeGen q (In3 (Pop m)); runCodeGen p qc
+shallow Empty         _ = do return $! In3 Empt
 shallow (p :<|>: q)   m = do altNoCutCompile p q parsecHandler id m
-shallow (Try p)       m = do fmap (In4 . flip Catch rollbackHandler) (runCodeGen p (deadCommitOptimisation m))
+shallow (Try p)       m = do fmap (In3 . flip Catch rollbackHandler) (runCodeGen p (deadCommitOptimisation m))
 shallow (LookAhead p) m =
-  do n <- fmap reclaimable (runCodeGen p (In4 Ret)) -- Dodgy hack, but oh well
-     fmap (In4 . Tell) (runCodeGen p (In4 (Swap (In4 (Seek (refundCoins n m))))))
+  do n <- fmap reclaimable (runCodeGen p (In3 Ret)) -- Dodgy hack, but oh well
+     fmap (In3 . Tell) (runCodeGen p (In3 (Swap (In3 (Seek (refundCoins n m))))))
 shallow (NotFollowedBy p) m =
-  do pc <- runCodeGen p (In4 (Pop (In4 (Seek (In4 (Commit (In4 Empt)))))))
+  do pc <- runCodeGen p (In3 (Pop (In3 (Seek (In3 (Commit (In3 Empt)))))))
      let np = coinsNeeded pc
      let nm = coinsNeeded m
      -- The minus here is used because the shared coins are propagated out front, neat.
-     return $! In4 (Catch (addCoins (maxCoins (np `minus` nm) zero) (In4 (Tell pc))) (Always (not (shouldInline m)) (In4 (Seek (In4 (Push (user UNIT) m))))))
+     return $! In3 (Catch (addCoins (maxCoins (np `minus` nm) zero) (In3 (Tell pc))) (Always (not (shouldInline m)) (In3 (Seek (In3 (Push (user UNIT) m))))))
 shallow (Branch b p q) m =
   do (binder, φ) <- makeΦ m
-     pc <- freshΦ (runCodeGen p (In4 (Swap (In4 (_App φ)))))
-     qc <- freshΦ (runCodeGen q (In4 (Swap (In4 (_App φ)))))
-     let minc = coinsNeeded (In4 (Case pc qc))
+     pc <- freshΦ (runCodeGen p (In3 (Swap (In3 (_App φ)))))
+     qc <- freshΦ (runCodeGen q (In3 (Swap (In3 (_App φ)))))
+     let minc = coinsNeeded (In3 (Case pc qc))
      let dp = maxCoins zero (coinsNeeded pc `minus` minc)
      let dq = maxCoins zero (coinsNeeded qc `minus` minc)
-     fmap binder (runCodeGen b (In4 (Case (addCoins dp pc) (addCoins dq qc))))
+     fmap binder (runCodeGen b (In3 (Case (addCoins dp pc) (addCoins dq qc))))
 shallow (Match p fs qs def) m =
   do (binder, φ) <- makeΦ m
      qcs <- traverse (\q -> freshΦ (runCodeGen q φ)) qs
      defc <- freshΦ (runCodeGen def φ)
-     let minc = coinsNeeded (In4 (Choices (map user fs) qcs defc))
+     let minc = coinsNeeded (In3 (Choices (map user fs) qcs defc))
      let defc':qcs' = map (maxCoins zero . (`minus` minc) . coinsNeeded >>= addCoins) (defc:qcs)
-     fmap binder (runCodeGen p (In4 (Choices (map user fs) qcs' defc')))
+     fmap binder (runCodeGen p (In3 (Choices (map user fs) qcs' defc')))
 shallow (Let _ μ)                    m = do return $! tailCallOptimise μ m
 shallow (Loop body exit)             m = do loopCompile body exit addCoinsNeeded id m
-shallow (MakeRegister σ p q)         m = do qc <- runCodeGen q m; runCodeGen p (In4 (_Make σ qc))
-shallow (GetRegister σ)              m = do return $! In4 (_Get σ m)
-shallow (PutRegister σ p)            m = do runCodeGen p (In4 (_Put σ (In4 (Push (user UNIT) m))))
-shallow (Position sel)               m = do return $! In4 (SelectPos sel m)
-shallow (Debug name p)               m = do fmap (In4 . LogEnter name) (runCodeGen p (In4 (Commit (In4 (LogExit name m)))))
+shallow (MakeRegister σ p q)         m = do qc <- runCodeGen q m; runCodeGen p (In3 (_Make σ qc))
+shallow (GetRegister σ)              m = do return $! In3 (_Get σ m)
+shallow (PutRegister σ p)            m = do runCodeGen p (In3 (_Put σ (In3 (Push (user UNIT) m))))
+shallow (Position sel)               m = do return $! In3 (SelectPos sel m)
+shallow (Debug name p)               m = do fmap (In3 . LogEnter name) (runCodeGen p (In3 (Commit (In3 (LogExit name m)))))
 shallow (MetaCombinator Cut p)       m = do blockCoins <$> runCodeGen p (addCoins (coinsNeeded m) m)
-shallow (MetaCombinator CutImmune p) m = do addCoins . coinsNeeded <$> runCodeGen p (In4 Ret) <*> runCodeGen p m
+shallow (MetaCombinator CutImmune p) m = do addCoins . coinsNeeded <$> runCodeGen p (In3 Ret) <*> runCodeGen p m
 
-tailCallOptimise :: MVar x -> Fix4 (Instr o) (x : xs) (Succ n) r a -> Fix4 (Instr o) xs (Succ n) r a
-tailCallOptimise μ (In4 Ret) = In4 (Jump μ)
-tailCallOptimise μ k         = In4 (Call μ k)
+tailCallOptimise :: MVar x -> Fix3 (Instr o) (x : xs) (Succ n) r -> Fix3 (Instr o) xs (Succ n) r
+tailCallOptimise μ (In3 Ret) = In3 (Jump μ)
+tailCallOptimise μ k         = In3 (Call μ k)
 
 -- Thanks to the optimisation applied to the K stack, commit is deadcode before Ret
 -- However, I'm not yet sure about the interactions with try yet...
-deadCommitOptimisation :: Fix4 (Instr o) xs n r a -> Fix4 (Instr o) xs (Succ n) r a
-deadCommitOptimisation (In4 Ret) = In4 Ret
-deadCommitOptimisation m         = In4 (Commit m)
+deadCommitOptimisation :: Fix3 (Instr o) xs n r -> Fix3 (Instr o) xs (Succ n) r
+deadCommitOptimisation (In3 Ret) = In3 Ret
+deadCommitOptimisation m         = In3 (Commit m)
 
 -- Refactor with asks
 askM :: CodeGenStack (MVar a)
@@ -184,18 +184,18 @@ freshM = mapVFreshT newScope
 freshΦ :: CodeGenStack a -> CodeGenStack a
 freshΦ = newScope
 
-makeΦ :: Trace => Fix4 (Instr o) (x ': xs) (Succ n) r a -> CodeGenStack (Fix4 (Instr o) xs (Succ n) r a -> Fix4 (Instr o) xs (Succ n) r a, Fix4 (Instr o) (x : xs) (Succ n) r a)
+makeΦ :: Trace => Fix3 (Instr o) (x ': xs) (Succ n) r -> CodeGenStack (Fix3 (Instr o) xs (Succ n) r -> Fix3 (Instr o) xs (Succ n) r, Fix3 (Instr o) (x : xs) (Succ n) r)
 makeΦ m | shouldInline m = trace ("eliding " ++ show m) $ return (id, m)
   {-where
-    elidable :: Fix4 (Instr o) (x ': xs) (Succ n) r a -> Bool
+    elidable :: Fix3 (Instr o) (x ': xs) (Succ n) r a -> Bool
     -- This is double-φ optimisation:   If a φ-node points shallowly to another φ-node, then it can be elided
-    elidable (In4 (Join _))             = True
-    elidable (In4 (Pop (In4 (Join _)))) = True
+    elidable (In3 (Join _))             = True
+    elidable (In3 (Pop (In3 (Join _)))) = True
     -- This is terminal-φ optimisation: If a φ-node points shallowly to a terminal operation, then it can be elided
-    elidable (In4 Ret)                  = True
-    elidable (In4 (Pop (In4 Ret)))      = True
+    elidable (In3 Ret)                  = True
+    elidable (In3 (Pop (In3 Ret)))      = True
     -- This is a form of double-φ optimisation: If a φ-node points shallowly to a jump, then it can be elided and the jump used instead
     -- Note that this should NOT be done for non-tail calls, as they may generate a large continuation
-    elidable (In4 (Pop (In4 (Jump _)))) = True
+    elidable (In3 (Pop (In3 (Jump _)))) = True
     elidable _                          = False-}
-makeΦ m = let n = coinsNeeded m in fmap (\φ -> (In4 . MkJoin φ (giveBursary n m), drainCoins n (In4 (Join φ)))) askΦ
+makeΦ m = let n = coinsNeeded m in fmap (\φ -> (In3 . MkJoin φ (giveBursary n m), drainCoins n (In3 (Join φ)))) askΦ

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/Instructions.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/Instructions.hs
@@ -33,7 +33,7 @@ import Data.Kind                                    (Type)
 import Data.Void                                    (Void)
 import Parsley.Internal.Backend.Machine.Identifiers (MVar, ΦVar, ΣVar)
 import Parsley.Internal.Backend.Machine.Types.Coins (Coins(Coins))
-import Parsley.Internal.Common                      (IFunctor4, Fix4(In4), Const4(..), imap4, cata4, Nat(..), One, intercalateDiff)
+import Parsley.Internal.Common                      (IFunctor3, Fix3(In3), Const3(..), imap3, cata3, Nat(..), One, intercalateDiff)
 import Parsley.Internal.Core.CombinatorAST          (PosSelector(..))
 import Parsley.Internal.Core.CharPred               (CharPred)
 
@@ -47,153 +47,152 @@ When an instruction has a `Succ` in the type, it indicates that it is capable of
 
 @since 1.4.0.0
 -}
-data Instr (o :: Type)                                  -- The FIXED input type
-           (k :: [Type] -> Nat -> Type -> Type -> Type) -- The FIXED continuation parameter
-           (xs :: [Type])                               -- The VARIABLE type defining the required types on the stack on entry
-           (n :: Nat)                                   -- The VARIABLE type defining how many handlers are required on entry
-           (r :: Type)                                  -- The VARIABLE intermediate type defining what value this parser immediately produces
-           (a :: Type)                                  -- The (technically VARIABLE) type specifying the final result of the parser
+data Instr (o :: Type)                          -- The FIXED input type
+           (k :: [Type] -> Nat -> Type -> Type) -- The FIXED continuation parameter
+           (xs :: [Type])                       -- The VARIABLE type defining the required types on the stack on entry
+           (n :: Nat)                           -- The VARIABLE type defining how many handlers are required on entry
+           (r :: Type)                          -- The VARIABLE intermediate type defining what value this parser immediately produces
   where
   {-| This instruction returns from either calls or the entire parser at the top-level.
 
   @since 1.0.0.0 -}
-  Ret       :: Instr o k '[x] n x a {- ^ -}
+  Ret       :: Instr o k '[x] n x {- ^ -}
   {-| Pushes a value onto the stack, which is required by the continuation parameter.
 
   @since 1.0.0.0 -}
-  Push      :: Machine.Defunc x {- ^ Value to push. -} -> k (x : xs) n r a {- ^ Machine requiring value. -} -> Instr o k xs n r a
+  Push      :: Machine.Defunc x {- ^ Value to push. -} -> k (x : xs) n r {- ^ Machine requiring value. -} -> Instr o k xs n r
   {-| Removes a value from the stack, so it is the correct shape for the continuation parameter.
 
   @since 1.0.0.0 -}
-  Pop       :: k xs n r a {- ^ -} -> Instr o k (x : xs) n r a
+  Pop       :: k xs n r {- ^ -} -> Instr o k (x : xs) n r
   {-| Applies a function to the top two elements of the stack, converting them to something else and pushing it back on.
 
   @since 1.0.0.0 -}
   Lift2     :: Machine.Defunc (x -> y -> z) {- ^ Function to apply. -}
-            -> k (z : xs) n r a             {- ^ Machine requiring new value. -}
-            -> Instr o k (y : x : xs) n r a
+            -> k (z : xs) n r               {- ^ Machine requiring new value. -}
+            -> Instr o k (y : x : xs) n r
   {-| Reads a character so long as it matches a given predicate. If it does not, or no input is available, this instruction fails.
 
   @since 2.1.0.0 -}
-  Sat       :: CharPred                   {- ^ Predicate to apply. -}
-            -> k (Char : xs) (Succ n) r a {- ^ Machine requiring read character. -}
-            -> Instr o k xs (Succ n) r a
+  Sat       :: CharPred                 {- ^ Predicate to apply. -}
+            -> k (Char : xs) (Succ n) r {- ^ Machine requiring read character. -}
+            -> Instr o k xs (Succ n) r
   {-| Calls another let-bound parser.
 
   @since 1.0.0.0 -}
-  Call      :: MVar x                  {- ^ The binding to invoke. -}
-            -> k (x : xs) (Succ n) r a {- ^ Continuation to do after the call. -}
-            -> Instr o k xs (Succ n) r a
+  Call      :: MVar x                {- ^ The binding to invoke. -}
+            -> k (x : xs) (Succ n) r {- ^ Continuation to do after the call. -}
+            -> Instr o k xs (Succ n) r
   {-| Jumps to another let-bound parser tail-recursively.
 
   @since 1.0.0.0 -}
-  Jump      :: MVar x {- ^ The binding to jump to. -} -> Instr o k '[] (Succ n) x a
+  Jump      :: MVar x {- ^ The binding to jump to. -} -> Instr o k '[] (Succ n) x
   {-| Fails unconditionally.
 
   @since 1.0.0.0 -}
-  Empt      :: Instr o k xs (Succ n) r a {- ^ -}
+  Empt      :: Instr o k xs (Succ n) r {- ^ -}
   {-| Discards a failure handler, so that it is no longer in scope.
 
   @since 1.0.0.0 -}
-  Commit    :: k xs n r a {- ^ Next machine, which will /not/ require the discarded handler. -} -> Instr o k xs (Succ n) r a
+  Commit    :: k xs n r {- ^ Next machine, which will /not/ require the discarded handler. -} -> Instr o k xs (Succ n) r
   {-| Registers a handler to deal with possible failure in the given machine.
 
   @since 1.4.0.0 -}
-  Catch     :: k xs (Succ n) r a          {- ^ Machine where failure is handled by the handler. -}
-            -> Handler o k (o : xs) n r a {- ^ The handler to register. -}
-            -> Instr o k xs n r a
+  Catch     :: k xs (Succ n) r          {- ^ Machine where failure is handled by the handler. -}
+            -> Handler o k (o : xs) n r {- ^ The handler to register. -}
+            -> Instr o k xs n r
   {-| Pushes the current input offset onto the stack.
 
   @since 1.0.0.0 -}
-  Tell      :: k (o : xs) n r a {- ^ The machine that accepts the input. -} -> Instr o k xs n r a
+  Tell      :: k (o : xs) n r {- ^ The machine that accepts the input. -} -> Instr o k xs n r
   {-| Pops the input offset off of the stack and makes that the current input offset.
 
   @since 1.0.0.0 -}
-  Seek      :: k xs n r a {- ^ Machine to continue with new input. -} -> Instr o k (o : xs) n r a
+  Seek      :: k xs n r {- ^ Machine to continue with new input. -} -> Instr o k (o : xs) n r
   {-| Picks one of two continuations based on whether a `Left` or `Right` is on the stack.
 
   @since 1.0.0.0 -}
-  Case      :: k (x : xs) n r a {- ^ Machine to execute if `Left` on stack. -}
-            -> k (y : xs) n r a {- ^ Machine to execute if `Right` on stack. -}
-            -> Instr o k (Either x y : xs) n r a
+  Case      :: k (x : xs) n r {- ^ Machine to execute if `Left` on stack. -}
+            -> k (y : xs) n r {- ^ Machine to execute if `Right` on stack. -}
+            -> Instr o k (Either x y : xs) n r
   {-| Given a collection of predicates and machines, this instruction will execute the first machine
       for which the corresponding predicate returns true for the value on the top of the stack.
 
   @since 1.0.0.0 -}
   Choices   :: [Machine.Defunc (x -> Bool)] {- ^ A list of predicates to try. -}
-            -> [k xs n r a]                 {- ^ A corresponding list of machines. -}
-            -> k xs n r a                   {- ^ A default machine to execute if no predicates match. -}
-            -> Instr o k (x : xs) n r a
+            -> [k xs n r]                   {- ^ A corresponding list of machines. -}
+            -> k xs n r                     {- ^ A default machine to execute if no predicates match. -}
+            -> Instr o k (x : xs) n r
   {-| Sets up an iteration, where the second argument is executed repeatedly until it fails, which is
       handled by the given handler. The use of `Void` indicates that `Ret` is illegal within the loop.
 
   @since 1.0.0.0 -}
-  Iter      :: MVar Void                  {- ^ The name of the binding. -}
-            -> k '[] One Void a           {- ^ The body of the loop: it cannot return "normally". -}
-            -> Handler o k (o : xs) n r a {- ^ The handler for the loop's exit. -}
-            -> Instr o k xs n r a
+  Iter      :: MVar Void                {- ^ The name of the binding. -}
+            -> k '[] One Void           {- ^ The body of the loop: it cannot return "normally". -}
+            -> Handler o k (o : xs) n r {- ^ The handler for the loop's exit. -}
+            -> Instr o k xs n r
   {-| Jumps to a given join point.
 
   @since 1.0.0.0 -}
-  Join      :: ΦVar x {- ^ The join point to jump to. -} -> Instr o k (x : xs) n r a
+  Join      :: ΦVar x {- ^ The join point to jump to. -} -> Instr o k (x : xs) n r
   {-| Sets up a new join point binding.
 
   @since 1.0.0.0 -}
-  MkJoin    :: ΦVar x           {- ^ The name of the binding that can be referred to later. -}
-            -> k (x : xs) n r a {- ^ The body of the join point binding. -}
-            -> k xs n r a       {- ^ The scope within which the binding is valid.  -}
-            -> Instr o k xs n r a
+  MkJoin    :: ΦVar x         {- ^ The name of the binding that can be referred to later. -}
+            -> k (x : xs) n r {- ^ The body of the join point binding. -}
+            -> k xs n r       {- ^ The scope within which the binding is valid.  -}
+            -> Instr o k xs n r
   {-| Swaps the top two elements on the stack
 
   @since 1.0.0.0 -}
-  Swap      :: k (x : y : xs) n r a {- ^ The machine that requires the reversed stack. -} -> Instr o k (y : x : xs) n r a
+  Swap      :: k (x : y : xs) n r {- ^ The machine that requires the reversed stack. -} -> Instr o k (y : x : xs) n r
   {-| Duplicates the top value on the stack. May produce a let-binding.
 
   @since 1.0.0.0 -}
-  Dup       :: k (x : x : xs) n r a {- ^ Machine that requires doubled element. -} -> Instr o k (x : xs) n r a
+  Dup       :: k (x : x : xs) n r {- ^ Machine that requires doubled element. -} -> Instr o k (x : xs) n r
   {-| Initialises a new register for use within the continuation. Initial value is on the stack.
 
   @since 1.0.0.0 -}
-  Make      :: ΣVar x     {- ^ The name of the new register. -}
-            -> Access     {- ^ Whether or not the register is "concrete". -}
-            -> k xs n r a {- ^ The scope within which the register is accessible. -}
-            -> Instr o k (x : xs) n r a
+  Make      :: ΣVar x   {- ^ The name of the new register. -}
+            -> Access   {- ^ Whether or not the register is "concrete". -}
+            -> k xs n r {- ^ The scope within which the register is accessible. -}
+            -> Instr o k (x : xs) n r
   {-| Pushes the value contained within a register onto the stack.
 
   @since 1.0.0.0 -}
-  Get       :: ΣVar x           {- ^ Name of the register to read. -}
-            -> Access           {- ^ Whether or not the value is cached. -}
-            -> k (x : xs) n r a {- ^ The machine that requires the value. -}
-            -> Instr o k xs n r a
+  Get       :: ΣVar x         {- ^ Name of the register to read. -}
+            -> Access         {- ^ Whether or not the value is cached. -}
+            -> k (x : xs) n r {- ^ The machine that requires the value. -}
+            -> Instr o k xs n r
   {-| Places the value on the top of the stack into a given register.
 
   @since 1.0.0.0 -}
-  Put       :: ΣVar x     {- ^ Name of the register to update. -}
-            -> Access     {- ^ Whether or not the value needs to be stored in a concrete register. -}
-            -> k xs n r a
-            -> Instr o k (x : xs) n r a
-  SelectPos :: PosSelector -> k (Int : xs) n r a -> Instr o k xs n r a
+  Put       :: ΣVar x   {- ^ Name of the register to update. -}
+            -> Access   {- ^ Whether or not the value needs to be stored in a concrete register. -}
+            -> k xs n r
+            -> Instr o k (x : xs) n r
+  SelectPos :: PosSelector -> k (Int : xs) n r -> Instr o k xs n r
   {-| Begins a debugging scope, the inner scope requires /two/ handlers,
       the first is the log handler itself, and then the second is the
       "real" fail handler for when the log handler is executed.
 
   @since 1.0.0.0 -}
-  LogEnter  :: String                   {- ^ The message to be printed. -}
-            -> k xs (Succ (Succ n)) r a {- ^ The machine to be debugged. -}
-            -> Instr o k xs (Succ n) r a
+  LogEnter  :: String                 {- ^ The message to be printed. -}
+            -> k xs (Succ (Succ n)) r {- ^ The machine to be debugged. -}
+            -> Instr o k xs (Succ n) r
   {-| Ends the log scope after a succesful execution.
 
   @since 1.0.0.0 -}
-  LogExit   :: String     {- ^ The message to be printed. -}
-            -> k xs n r a {- ^ The machine that follows. -}
-            -> Instr o k xs n r a
+  LogExit   :: String   {- ^ The message to be printed. -}
+            -> k xs n r {- ^ The machine that follows. -}
+            -> Instr o k xs n r
   {-| Executes a meta-instruction, which is interacting with
       implementation specific static information.
 
   @since 1.0.0.0 -}
   MetaInstr :: MetaInstr n {- ^ A meta-instruction to perform. -}
-            -> k xs n r a  {- ^ The machine that follows. -}
-            -> Instr o k xs n r a
+            -> k xs n r    {- ^ The machine that follows. -}
+            -> Instr o k xs n r
 
 {-|
 There are two types of organic handlers within parsley, which are
@@ -202,23 +201,23 @@ captured by this type, which is also an IFunctor and wraps around
 
 @since 1.4.0.0
 -}
-data Handler (o :: Type) (k :: [Type] -> Nat -> Type -> Type -> Type) (xs :: [Type]) (n :: Nat) (r :: Type) (a :: Type) where
+data Handler (o :: Type) (k :: [Type] -> Nat -> Type -> Type) (xs :: [Type]) (n :: Nat) (r :: Type) where
   {-| These handlers have two distinct behaviours depending on whether the
       captured offset matches the current offset or not.
 
   @since 1.4.0.0 -}
-  Same :: Bool             -- ^ Whether the input matches handler should generate a binding
-       -> k xs n r a       -- ^ Execute when the input matches, notice that the captured offset is discarded since it is equal to the current.
-       -> Bool             -- ^ Whether the input does not match handler should generate a binding
-       -> k (o : xs) n r a -- ^ Execute when the input does not match, the resulting behaviour could use the captured or current input.
-       -> Handler o k (o : xs) n r a
+  Same :: Bool           -- ^ Whether the input matches handler should generate a binding
+       -> k xs n r       -- ^ Execute when the input matches, notice that the captured offset is discarded since it is equal to the current.
+       -> Bool           -- ^ Whether the input does not match handler should generate a binding
+       -> k (o : xs) n r -- ^ Execute when the input does not match, the resulting behaviour could use the captured or current input.
+       -> Handler o k (o : xs) n r
   {-| These handlers are unconditional on the input, and will always do the same
       thing regardless of the input provided.
 
   @since 1.7.0.0 -}
-  Always :: Bool             -- ^ Whether the handler should generate a binding
-         -> k (o : xs) n r a -- ^ The handler
-         -> Handler o k (o : xs) n r a
+  Always :: Bool           -- ^ Whether the handler should generate a binding
+         -> k (o : xs) n r -- ^ The handler
+         -> Handler o k (o : xs) n r
 
 {-|
 This determines whether or not an interaction with an register should be materialised
@@ -276,16 +275,16 @@ data MetaInstr (n :: Nat) where
   -}
   BlockCoins :: MetaInstr n
 
-mkCoin :: (Coins -> MetaInstr n) -> Coins -> Fix4 (Instr o) xs n r a -> Fix4 (Instr o) xs n r a
+mkCoin :: (Coins -> MetaInstr n) -> Coins -> Fix3 (Instr o) xs n r -> Fix3 (Instr o) xs n r
 mkCoin _    (Coins 0 0) = id
-mkCoin meta n           = In4 . MetaInstr (meta n)
+mkCoin meta n           = In3 . MetaInstr (meta n)
 
 {-|
 Smart-constuctor around `AddCoins`.
 
 @since 1.5.0.0
 -}
-addCoins :: Coins -> Fix4 (Instr o) xs (Succ n) r a -> Fix4 (Instr o) xs (Succ n) r a
+addCoins :: Coins -> Fix3 (Instr o) xs (Succ n) r -> Fix3 (Instr o) xs (Succ n) r
 addCoins (Coins 1 1) = id
 addCoins coins       = mkCoin AddCoins coins
 
@@ -294,7 +293,7 @@ Smart-constuctor around `RefundCoins`.
 
 @since 1.5.0.0
 -}
-refundCoins :: Coins -> Fix4 (Instr o) xs n r a -> Fix4 (Instr o) xs n r a
+refundCoins :: Coins -> Fix3 (Instr o) xs n r -> Fix3 (Instr o) xs n r
 refundCoins = mkCoin RefundCoins
 
 {-|
@@ -302,7 +301,7 @@ Smart-constuctor around `DrainCoins`.
 
 @since 1.5.0.0
 -}
-drainCoins :: Coins -> Fix4 (Instr o) xs (Succ n) r a -> Fix4 (Instr o) xs (Succ n) r a
+drainCoins :: Coins -> Fix3 (Instr o) xs (Succ n) r -> Fix3 (Instr o) xs (Succ n) r
 drainCoins = mkCoin DrainCoins
 
 {-|
@@ -310,7 +309,7 @@ Smart-constuctor around `RefundCoins`.
 
 @since 1.5.0.0
 -}
-giveBursary :: Coins -> Fix4 (Instr o) xs n r a -> Fix4 (Instr o) xs n r a
+giveBursary :: Coins -> Fix3 (Instr o) xs n r -> Fix3 (Instr o) xs n r
 giveBursary = mkCoin GiveBursary
 
 {-|
@@ -318,23 +317,23 @@ Smart-constructor around `PrefetchChar`.
 
 @since 1.5.0.0
 -}
-prefetchChar :: Bool -> Fix4 (Instr o) xs (Succ n) r a -> Fix4 (Instr o) xs (Succ n) r a
-prefetchChar check = In4 . MetaInstr (PrefetchChar check)
+prefetchChar :: Bool -> Fix3 (Instr o) xs (Succ n) r -> Fix3 (Instr o) xs (Succ n) r
+prefetchChar check = In3 . MetaInstr (PrefetchChar check)
 
 {-|
 Smart-constructor around `BlockCoins`.
 
 @since 1.6.0.0
 -}
-blockCoins :: Fix4 (Instr o) xs (Succ n) r a -> Fix4 (Instr o) xs (Succ n) r a
-blockCoins = In4 . MetaInstr BlockCoins
+blockCoins :: Fix3 (Instr o) xs (Succ n) r -> Fix3 (Instr o) xs (Succ n) r
+blockCoins = In3 . MetaInstr BlockCoins
 
 {-|
 Applies a value on the top of the stack to a function on the second-most top of the stack.
 
 @since 1.0.0.0
 -}
-_App :: Fix4 (Instr o) (y : xs) n r a -> Instr o (Fix4 (Instr o)) (x : (x -> y) : xs) n r a
+_App :: Fix3 (Instr o) (y : xs) n r -> Instr o (Fix3 (Instr o)) (x : (x -> y) : xs) n r
 _App = Lift2 (user ID)
 
 {-|
@@ -342,23 +341,23 @@ Adjusts the value on the top of the stack with the given function.
 
 @since 1.0.0.0
 -}
-_Fmap :: Machine.Defunc (x -> y) -> Fix4 (Instr o) (y : xs) n r a -> Instr o (Fix4 (Instr o)) (x : xs) n r a
-_Fmap f k = Push f (In4 (Lift2 (user (FLIP_H ID)) k))
+_Fmap :: Machine.Defunc (x -> y) -> Fix3 (Instr o) (y : xs) n r -> Instr o (Fix3 (Instr o)) (x : xs) n r
+_Fmap f k = Push f (In3 (Lift2 (user (FLIP_H ID)) k))
 
 {-|
 Updates the value in a given register using the function on the top of the stack.
 
 @since 1.0.0.0
 -}
-_Modify :: ΣVar x -> Fix4 (Instr o) xs n r a -> Instr o (Fix4 (Instr o)) ((x -> x) : xs) n r a
-_Modify σ  = _Get σ . In4 . _App . In4 . _Put σ
+_Modify :: ΣVar x -> Fix3 (Instr o) xs n r -> Instr o (Fix3 (Instr o)) ((x -> x) : xs) n r
+_Modify σ  = _Get σ . In3 . _App . In3 . _Put σ
 
 {-|
 Smart-instruction for `Make` that uses a `Hard` access.
 
 @since 1.0.0.0
 -}
-_Make :: ΣVar x -> k xs n r a -> Instr o k (x : xs) n r a
+_Make :: ΣVar x -> k xs n r -> Instr o k (x : xs) n r
 _Make σ = Make σ Hard
 
 {-|
@@ -366,7 +365,7 @@ Smart-instruction for `Put` that uses a `Hard` access.
 
 @since 1.0.0.0
 -}
-_Put :: ΣVar x -> k xs n r a -> Instr o k (x : xs) n r a
+_Put :: ΣVar x -> k xs n r -> Instr o k (x : xs) n r
 _Put σ = Put σ Hard
 
 {-|
@@ -374,78 +373,78 @@ Smart-instruction for `Get` that uses a `Hard` access.
 
 @since 1.0.0.0
 -}
-_Get :: ΣVar x -> k (x : xs) n r a -> Instr o k xs n r a
+_Get :: ΣVar x -> k (x : xs) n r -> Instr o k xs n r
 _Get σ = Get σ Hard
 
 -- Instances
-instance IFunctor4 (Instr o) where
-  imap4 _ Ret                 = Ret
-  imap4 f (Push x k)          = Push x (f k)
-  imap4 f (Pop k)             = Pop (f k)
-  imap4 f (Lift2 g k)         = Lift2 g (f k)
-  imap4 f (Sat g k)           = Sat g (f k)
-  imap4 f (Call μ k)          = Call μ (f k)
-  imap4 _ (Jump μ)            = Jump μ
-  imap4 _ Empt                = Empt
-  imap4 f (Commit k)          = Commit (f k)
-  imap4 f (Catch p h)         = Catch (f p) (imap4 f h)
-  imap4 f (Tell k)            = Tell (f k)
-  imap4 f (Seek k)            = Seek (f k)
-  imap4 f (Case p q)          = Case (f p) (f q)
-  imap4 f (Choices fs ks def) = Choices fs (map f ks) (f def)
-  imap4 f (Iter μ l h)        = Iter μ (f l) (imap4 f h)
-  imap4 _ (Join φ)            = Join φ
-  imap4 f (MkJoin φ p k)      = MkJoin φ (f p) (f k)
-  imap4 f (Swap k)            = Swap (f k)
-  imap4 f (Dup k)             = Dup (f k)
-  imap4 f (Make σ a k)        = Make σ a (f k)
-  imap4 f (Get σ a k)         = Get σ a (f k)
-  imap4 f (Put σ a k)         = Put σ a (f k)
-  imap4 f (SelectPos sel k)   = SelectPos sel (f k)
-  imap4 f (LogEnter name k)   = LogEnter name (f k)
-  imap4 f (LogExit name k)    = LogExit name (f k)
-  imap4 f (MetaInstr m k)     = MetaInstr m (f k)
+instance IFunctor3 (Instr o) where
+  imap3 _ Ret                 = Ret
+  imap3 f (Push x k)          = Push x (f k)
+  imap3 f (Pop k)             = Pop (f k)
+  imap3 f (Lift2 g k)         = Lift2 g (f k)
+  imap3 f (Sat g k)           = Sat g (f k)
+  imap3 f (Call μ k)          = Call μ (f k)
+  imap3 _ (Jump μ)            = Jump μ
+  imap3 _ Empt                = Empt
+  imap3 f (Commit k)          = Commit (f k)
+  imap3 f (Catch p h)         = Catch (f p) (imap3 f h)
+  imap3 f (Tell k)            = Tell (f k)
+  imap3 f (Seek k)            = Seek (f k)
+  imap3 f (Case p q)          = Case (f p) (f q)
+  imap3 f (Choices fs ks def) = Choices fs (map f ks) (f def)
+  imap3 f (Iter μ l h)        = Iter μ (f l) (imap3 f h)
+  imap3 _ (Join φ)            = Join φ
+  imap3 f (MkJoin φ p k)      = MkJoin φ (f p) (f k)
+  imap3 f (Swap k)            = Swap (f k)
+  imap3 f (Dup k)             = Dup (f k)
+  imap3 f (Make σ a k)        = Make σ a (f k)
+  imap3 f (Get σ a k)         = Get σ a (f k)
+  imap3 f (Put σ a k)         = Put σ a (f k)
+  imap3 f (SelectPos sel k)   = SelectPos sel (f k)
+  imap3 f (LogEnter name k)   = LogEnter name (f k)
+  imap3 f (LogExit name k)    = LogExit name (f k)
+  imap3 f (MetaInstr m k)     = MetaInstr m (f k)
 
-instance IFunctor4 (Handler o) where
-  imap4 f (Same gyes yes gno no) = Same gyes (f yes) gno (f no)
-  imap4 f (Always gk k)          = Always gk (f k)
+instance IFunctor3 (Handler o) where
+  imap3 f (Same gyes yes gno no) = Same gyes (f yes) gno (f no)
+  imap3 f (Always gk k)          = Always gk (f k)
 
-instance Show (Fix4 (Instr o) xs n r a) where
-  show = ($ "") . getConst4 . cata4 (Const4 . alg)
+instance Show (Fix3 (Instr o) xs n r) where
+  show = ($ "") . getConst3 . cata3 (Const3 . alg)
     where
-      alg :: forall xs n r a. Instr o (Const4 (String -> String)) xs n r a -> String -> String
+      alg :: forall xs n r. Instr o (Const3 (String -> String)) xs n r -> String -> String
       alg Ret                      = "Ret"
-      alg (Call μ k)               = "(Call " . shows μ . " " . getConst4 k . ")"
+      alg (Call μ k)               = "(Call " . shows μ . " " . getConst3 k . ")"
       alg (Jump μ)                 = "(Jump " . shows μ . ")"
-      alg (Push x k)               = "(Push " . shows x . " " . getConst4 k . ")"
-      alg (Pop k)                  = "(Pop " . getConst4 k . ")"
-      alg (Lift2 f k)              = "(Lift2 " . shows f . " " . getConst4 k . ")"
-      alg (Sat f k)                = "(Sat " . shows f . " " . getConst4 k . ")"
+      alg (Push x k)               = "(Push " . shows x . " " . getConst3 k . ")"
+      alg (Pop k)                  = "(Pop " . getConst3 k . ")"
+      alg (Lift2 f k)              = "(Lift2 " . shows f . " " . getConst3 k . ")"
+      alg (Sat f k)                = "(Sat " . shows f . " " . getConst3 k . ")"
       alg Empt                     = "Empt"
-      alg (Commit k)               = "(Commit " . getConst4 k . ")"
-      alg (Catch p h)              = "(Catch " . getConst4 p . " " . shows h . ")"
-      alg (Tell k)                 = "(Tell " . getConst4 k . ")"
-      alg (Seek k)                 = "(Seek " . getConst4 k . ")"
-      alg (Case p q)               = "(Case " . getConst4 p . " " . getConst4 q . ")"
-      alg (Choices fs ks def)      = "(Choices " . shows fs . " [" . intercalateDiff ", " (map getConst4 ks) . "] " . getConst4 def . ")"
-      alg (Iter μ l h)             = "{Iter " . shows μ . " " . getConst4 l . " " . shows h . "}"
+      alg (Commit k)               = "(Commit " . getConst3 k . ")"
+      alg (Catch p h)              = "(Catch " . getConst3 p . " " . shows h . ")"
+      alg (Tell k)                 = "(Tell " . getConst3 k . ")"
+      alg (Seek k)                 = "(Seek " . getConst3 k . ")"
+      alg (Case p q)               = "(Case " . getConst3 p . " " . getConst3 q . ")"
+      alg (Choices fs ks def)      = "(Choices " . shows fs . " [" . intercalateDiff ", " (map getConst3 ks) . "] " . getConst3 def . ")"
+      alg (Iter μ l h)             = "{Iter " . shows μ . " " . getConst3 l . " " . shows h . "}"
       alg (Join φ)                 = shows φ
-      alg (MkJoin φ p k)           = "(let " . shows φ . " = " . getConst4 p . " in " . getConst4 k . ")"
-      alg (Swap k)                 = "(Swap " . getConst4 k . ")"
-      alg (Dup k)                  = "(Dup " . getConst4 k . ")"
-      alg (Make σ a k)             = "(Make " . shows σ . " " . shows a . " " . getConst4 k . ")"
-      alg (Get σ a k)              = "(Get " . shows σ . " " . shows a . " " . getConst4 k . ")"
-      alg (Put σ a k)              = "(Put " . shows σ . " " . shows a . " " . getConst4 k . ")"
-      alg (SelectPos Line k)       = "(Line " . getConst4 k . ")"
-      alg (SelectPos Col k)        = "(Col " . getConst4 k . ")"
-      alg (LogEnter _ k)           = getConst4 k
-      alg (LogExit _ k)            = getConst4 k
-      alg (MetaInstr BlockCoins k) = getConst4 k
-      alg (MetaInstr m k)          = "[" . shows m . "] " . getConst4 k
+      alg (MkJoin φ p k)           = "(let " . shows φ . " = " . getConst3 p . " in " . getConst3 k . ")"
+      alg (Swap k)                 = "(Swap " . getConst3 k . ")"
+      alg (Dup k)                  = "(Dup " . getConst3 k . ")"
+      alg (Make σ a k)             = "(Make " . shows σ . " " . shows a . " " . getConst3 k . ")"
+      alg (Get σ a k)              = "(Get " . shows σ . " " . shows a . " " . getConst3 k . ")"
+      alg (Put σ a k)              = "(Put " . shows σ . " " . shows a . " " . getConst3 k . ")"
+      alg (SelectPos Line k)       = "(Line " . getConst3 k . ")"
+      alg (SelectPos Col k)        = "(Col " . getConst3 k . ")"
+      alg (LogEnter _ k)           = getConst3 k
+      alg (LogExit _ k)            = getConst3 k
+      alg (MetaInstr BlockCoins k) = getConst3 k
+      alg (MetaInstr m k)          = "[" . shows m . "] " . getConst3 k
 
-instance Show (Handler o (Const4 (String -> String)) (o : xs) n r a) where
-  show (Same _ yes _ no) = "(Dup (Tell (Lift2 same (If " (getConst4 yes (" " (getConst4 no "))))")))
-  show (Always _ k)      = getConst4 k ""
+instance Show (Handler o (Const3 (String -> String)) (o : xs) n r) where
+  show (Same _ yes _ no) = "(Dup (Tell (Lift2 same (If " (getConst3 yes (" " (getConst3 no "))))")))
+  show (Always _ k)      = getConst3 k ""
 
 instance Show (MetaInstr n) where
   show (AddCoins n)     = "Add " ++ show n ++ " coins"

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/LetBindings.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/LetBindings.hs
@@ -26,7 +26,7 @@ import Data.Some                                                  (Some, pattern
 import Parsley.Internal.Backend.Machine.Identifiers               (ΣVar, SomeΣVar(..))
 import Parsley.Internal.Backend.Machine.Instructions              (Instr)
 import Parsley.Internal.Backend.Machine.Types.InputCharacteristic (InputCharacteristic(..))
-import Parsley.Internal.Common                                    (Fix4, One)
+import Parsley.Internal.Common                                    (Fix3, One)
 
 {-|
 Type represents a binding, which is a completed parser that can
@@ -36,7 +36,7 @@ the one of type @`Binding` o a a@.
 
 @since 1.0.0.0
 -}
-type Binding o a x = Fix4 (Instr o) '[] One x a
+type Binding o x = Fix3 (Instr o) '[] One x
 
 {-|
 Packages a binding along with its free registers that are required
@@ -47,8 +47,8 @@ from analysis.
 
 @since 1.5.0.0
 -}
-data LetBinding o a x = LetBinding {
-    body :: Binding o a x,
+data LetBinding o x = LetBinding {
+    body :: Binding o x,
     freeRegs :: Some Regs,
     meta :: Metadata
   }
@@ -82,7 +82,7 @@ Given a `Binding` , a set of existential `ΣVar`s, and some `Metadata`, produces
 
 @since 1.5.0.0
 -}
-makeLetBinding :: Binding o a x -> Set SomeΣVar -> Metadata -> LetBinding o a x
+makeLetBinding :: Binding o x -> Set SomeΣVar -> Metadata -> LetBinding o x
 makeLetBinding m rs = LetBinding m (makeRegs rs)
 
 {-|

--- a/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/LetRecBuilder.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Backend/Machine/LetRecBuilder.hs
@@ -33,9 +33,9 @@ refer to every other. These are then in scope for the top-level parser.
 @since 1.5.0.0
 -}
 letRec :: GCompare key
-       => {-bindings-}  DMap key (LetBinding o a)   -- ^ The bindings that should form part of the recursive group
+       => {-bindings-}  DMap key (LetBinding o)   -- ^ The bindings that should form part of the recursive group
       -> {-nameof-}     (forall x. key x -> String) -- ^ A function which can give a name to a key in the map
-      -> {-genBinding-} (forall x rs. key x -> Binding o a x -> Regs rs -> DMap key (QSubroutine s o a) -> Metadata -> Code (Func rs s o a x))
+      -> {-genBinding-} (forall x rs. key x -> Binding o x -> Regs rs -> DMap key (QSubroutine s o a) -> Metadata -> Code (Func rs s o a x))
       -- ^ How a binding - and their free registers - should be converted into code
       -> {-expr-}       (DMap key (QSubroutine s o a) -> Code b)
       -- ^ How to produce the top-level binding given the compiled bindings, i.e. the @in@ for the @let@

--- a/parsley-core/src/ghc/Parsley/Internal/Common/Indexed.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Common/Indexed.hs
@@ -11,17 +11,17 @@ type One = Succ Zero
 class IFunctor (f :: (Type -> Type) -> Type -> Type) where
   imap :: (forall j. a j -> b j) -> f a i -> f b i
 
-class IFunctor4 (f :: ([Type] -> Nat -> Type -> Type -> Type) -> [Type] -> Nat -> Type -> Type -> Type) where
-  imap4 :: (forall i' j' k'. a i' j' k' x -> b i' j' k' x) -> f a i j k x -> f b i j k x
+class IFunctor3 (f :: ([Type] -> Nat -> Type -> Type) -> [Type] -> Nat -> Type -> Type) where
+  imap3 :: (forall i' j' k'. a i' j' k' -> b i' j' k') -> f a i j k -> f b i j k
 
 newtype Fix f a = In (f (Fix f) a)
-newtype Fix4 f i j k l = In4 (f (Fix4 f) i j k l)
+newtype Fix3 f i j k = In3 (f (Fix3 f) i j k)
 
 inop :: Fix f a -> f (Fix f) a
 inop (In x) = x
 
-inop4 :: Fix4 f i j k l -> f (Fix4 f) i j k l
-inop4 (In4 x) = x
+inop3 :: Fix3 f i j k -> f (Fix3 f) i j k
+inop3 (In3 x) = x
 
 cata :: forall f a i. IFunctor f => (forall j. f a j -> a j) -> Fix f i -> a i
 cata alg = go where
@@ -35,12 +35,12 @@ cata' alg = go where
   go :: Fix f j -> a j
   go i@(In x) = alg i (imap go x)
 
-cata4 :: forall f a i j k x. IFunctor4 f =>
-         (forall i' j' k'. f a i' j' k' x -> a i' j' k' x) ->
-         Fix4 f i j k x -> a i j k x
-cata4 alg = go where
-  go :: Fix4 f i' j' k' x -> a i' j' k' x
-  go (In4 x) = alg (imap4 go x)
+cata3 :: forall f a i j k. IFunctor3 f =>
+         (forall i' j' k'. f a i' j' k' -> a i' j' k') ->
+         Fix3 f i j k -> a i j k
+cata3 alg = go where
+  go :: Fix3 f i' j' k' -> a i' j' k'
+  go (In3 x) = alg (imap3 go x)
 
 data (f :+: g) k a where
   L :: f k a -> (f :+: g) k a
@@ -94,5 +94,5 @@ instance {-# OVERLAPS #-}     Chain a (Maybe a) where (|>) = liftA2 (<|>)
 data Unit1 k = Unit
 newtype Const1 a k = Const1 {getConst1 :: a}
 
-data Unit4 i j k l = Unit4
-newtype Const4 a i j k l = Const4 {getConst4 :: a}
+data Unit3 i j k = Unit3
+newtype Const3 a i j k = Const3 {getConst3 :: a}

--- a/parsley-core/test/Regression/Issue27.hs
+++ b/parsley-core/test/Regression/Issue27.hs
@@ -8,7 +8,7 @@ import Test.Tasty.HUnit
 
 import Parsley.Internal
 import Parsley.Internal.Core.CombinatorAST (Parser(unParser), Combinator)
-import Parsley.Internal.Common (Fix(In), Fix4(In4), cata, (\/))
+import Parsley.Internal.Common (Fix(In), Fix3(In3), cata, (\/))
 import Parsley.Internal.Backend.CodeGenerator (codeGen)
 import Parsley.Internal.Backend.Machine.LetBindings (Binding, body)
 import Parsley.Internal.Backend.Machine.Types.Coins (willConsume)
@@ -28,7 +28,7 @@ string str = foldr (\c p -> satisfy (EQ_H (LIFTED c)) *> p) (pure (LIFTED str)) 
 toAST :: Parser a -> Fix Combinator a
 toAST = cata (In \/ undefined) . unParser
 
-codeGen' :: Fix Combinator a -> Binding o a a
+codeGen' :: Fix Combinator a -> Binding o a
 codeGen' p = body (codeGen Nothing p Set.empty 0)
 
 ex1_p :: Fix Combinator String
@@ -55,12 +55,12 @@ ex7_p = toAST $ (string "abc" <|> string "123") *> string "..." <|> string "def"
 ex8_p :: Fix Combinator String
 ex8_p = toAST $ (try (string "abc") <|> string "ade") *> string "..." <|> string "def"
 
-leadingCoinsUnderCatch :: Fix4 (Instr o) xs n r a -> Maybe Int
-leadingCoinsUnderCatch (In4 (Catch (In4 (MetaInstr (AddCoins c) _)) _)) = Just (willConsume c)
+leadingCoinsUnderCatch :: Fix3 (Instr o) xs n r -> Maybe Int
+leadingCoinsUnderCatch (In3 (Catch (In3 (MetaInstr (AddCoins c) _)) _)) = Just (willConsume c)
 leadingCoinsUnderCatch _ = Nothing
 
-leadingCoins :: Fix4 (Instr o) xs n r a -> Maybe Int
-leadingCoins (In4 (MetaInstr (AddCoins c) _)) = Just (willConsume c)
+leadingCoins :: Fix3 (Instr o) xs n r -> Maybe Int
+leadingCoins (In3 (MetaInstr (AddCoins c) _)) = Just (willConsume c)
 leadingCoins _ = Nothing
 
 test1 :: Assertion


### PR DESCRIPTION
Removed the goal type `a` from the `Instr` functor, because it isn't needed. It is still required, however, by `Machine` and `MachineMonad`.