### PR TITLE
Improved input binding time

### DIFF
--- a/parsley-core/parsley-core.cabal
+++ b/parsley-core/parsley-core.cabal
@@ -140,7 +140,7 @@ library
                        dependent-map        >= 0.4.0   && < 0.5,
                        dependent-sum        >= 0.7.1   && < 0.8,
                        pretty-terminal      >= 0.1.0   && < 0.2,
-                       text                 >= 1.2.3   && < 1.3,
+                       text                 >= 1.2.3   && < 2.1,
                        -- Not sure about this one, 0.11.0.0 introduced a type synonym for PS, so it _should_ work
                        bytestring           >= 0.10.8  && < 0.12,
                        rangeset             >= 0.0.1   && < 0.2,

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine.hs
@@ -22,7 +22,7 @@ import Data.Dependent.Map                            (DMap)
 import Data.Text                                     (Text)
 import Parsley.Internal.Backend.Machine.Defunc       (user)
 import Parsley.Internal.Backend.Machine.Identifiers
-import Parsley.Internal.Backend.Machine.InputOps     (InputPrep(..))
+import Parsley.Internal.Backend.Machine.InputOps     (InputPrep, prepareCPS)
 import Parsley.Internal.Backend.Machine.Instructions
 import Parsley.Internal.Backend.Machine.LetBindings  (LetBinding, makeLetBinding, newMeta)
 import Parsley.Internal.Backend.Machine.Ops          (Ops)
@@ -41,7 +41,7 @@ for a parser.
 @since 0.1.0.0
 -}
 eval :: forall input a. (Input input, Trace) => Code input -> (LetBinding input a a, DMap MVar (LetBinding input a)) -> Code (Maybe a)
-eval input (toplevel, bindings) = Eval.eval (prepare input) toplevel bindings
+eval input (toplevel, bindings) = prepareCPS input (Eval.eval toplevel bindings)
 
 {-|
 This class is exposed to parsley itself and is used to denote which types may be

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine.hs
@@ -22,7 +22,7 @@ import Data.Dependent.Map                            (DMap)
 import Data.Text                                     (Text)
 import Parsley.Internal.Backend.Machine.Defunc       (user)
 import Parsley.Internal.Backend.Machine.Identifiers
-import Parsley.Internal.Backend.Machine.InputOps     (InputPrep, prepareCPS)
+import Parsley.Internal.Backend.Machine.InputOps     (InputPrep, prepare)
 import Parsley.Internal.Backend.Machine.Instructions
 import Parsley.Internal.Backend.Machine.LetBindings  (LetBinding, makeLetBinding, newMeta)
 import Parsley.Internal.Backend.Machine.Ops          (Ops)
@@ -41,7 +41,7 @@ for a parser.
 @since 0.1.0.0
 -}
 eval :: forall input a. (Input input, Trace) => Code input -> (LetBinding input a a, DMap MVar (LetBinding input a)) -> Code (Maybe a)
-eval input (toplevel, bindings) = prepareCPS input (Eval.eval toplevel bindings)
+eval input (toplevel, bindings) = prepare input (Eval.eval toplevel bindings)
 
 {-|
 This class is exposed to parsley itself and is used to denote which types may be

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Eval.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Eval.hs
@@ -55,13 +55,13 @@ eval :: forall o a. (Trace, Ops o)
      -> LetBinding o a a              -- ^ The binding to be generated.
      -> DMap MVar (LetBinding o a)    -- ^ The map of all other required bindings.
      -> Code (Maybe a)                -- ^ The code for this parser.
-eval input binding fs = trace "EVALUATING TOP LEVEL" [|| runST $
-  do let !(# next, more, offset #) = $$input
-     $$(let ?ops = InputOps [||more||] [||next||]
+eval input binding fs = trace "EVALUATING TOP LEVEL" [||
+    let !(# next, more, offset #) = $$input in
+    runST $$(let ?ops = InputOps [||more||] [||next||]
         in letRec fs
              nameLet
              (\μ exp rs names -> buildRec μ rs (emptyCtx names) (readyMachine exp))
-             (run (readyMachine (body binding)) (Γ Empty halt (mkInput [||offset||] initPos) (VCons fatal VNil)) . nextUnique . emptyCtx))
+             (\names -> run (readyMachine (body binding)) (Γ Empty halt (mkInput [||offset||] initPos) (VCons fatal VNil)) (nextUnique (emptyCtx names))))
   ||]
   where
     nameLet :: MVar x -> String

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Eval.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/Eval.hs
@@ -26,7 +26,7 @@ import Control.Monad.Reader                                (ask, asks, reader, l
 import Control.Monad.ST                                    (runST)
 import Parsley.Internal.Backend.Machine.Defunc             (Defunc(INPUT, LAM), pattern FREEVAR, genDefunc, ap, ap2, _if)
 import Parsley.Internal.Backend.Machine.Identifiers        (MVar(..), ΦVar, ΣVar)
-import Parsley.Internal.Backend.Machine.InputOps           (InputDependant, InputOps(InputOps))
+import Parsley.Internal.Backend.Machine.InputOps           (InputOps)
 import Parsley.Internal.Backend.Machine.InputRep           (Rep)
 import Parsley.Internal.Backend.Machine.Instructions       (Instr(..), MetaInstr(..), Access(..), Handler(..), PosSelector(..))
 import Parsley.Internal.Backend.Machine.LetBindings        (LetBinding(body))
@@ -50,18 +50,16 @@ This function performs the evaluation on the top-level let-bound parser to conve
 
 @since 1.0.0.0
 -}
-eval :: forall o a. (Trace, Ops o)
-     => Code (InputDependant (Rep o)) -- ^ The input as provided by the user.
-     -> LetBinding o a a              -- ^ The binding to be generated.
+eval :: forall o a. (Trace, Ops o, ?ops :: InputOps (Rep o))
+     => LetBinding o a a              -- ^ The binding to be generated.
      -> DMap MVar (LetBinding o a)    -- ^ The map of all other required bindings.
+     -> Code (Rep o)
      -> Code (Maybe a)                -- ^ The code for this parser.
-eval input binding fs = trace "EVALUATING TOP LEVEL" [||
-    let !(# next, more, offset #) = $$input in
-    runST $$(let ?ops = InputOps [||more||] [||next||]
-        in letRec fs
+eval binding fs offset  = trace "EVALUATING TOP LEVEL" [||
+    runST $$(letRec fs
              nameLet
              (\μ exp rs names -> buildRec μ rs (emptyCtx names) (readyMachine exp))
-             (\names -> run (readyMachine (body binding)) (Γ Empty halt (mkInput [||offset||] initPos) (VCons fatal VNil)) (nextUnique (emptyCtx names))))
+             (run (readyMachine (body binding)) (Γ Empty halt (mkInput offset initPos) (VCons fatal VNil)) . nextUnique . emptyCtx))
   ||]
   where
     nameLet :: MVar x -> String

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/InputOps.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/InputOps.hs
@@ -131,6 +131,11 @@ synthesised and passed around using @ImplicitParams@.
 
 @since 1.0.0.0
 -}
+-- TODO: more replaced by `check` which asks for N characters, maybe caching up to M of them (M < N)
+--       idea is that establishing if there are N characters may transitively read (or generate
+--       static expressions for) M characters (N-M we don't ever need and can ask to not have).
+--       If a type of input cannot produce these characters because it would be too expensive, fine
+--       an empty list is returned, and consuming characters must use `next` anyway.
 data InputOps (rep :: TYPE r) = InputOps { _more :: !(Code rep -> Code Bool)                                             -- ^ Does the input have any more characters?
                                          , _next :: !(forall a. Code rep -> (Code Char -> Code rep -> Code a) -> Code a) -- ^ Read the next character (without checking existence)
                                          }

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/InputOps.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/InputOps.hs
@@ -18,7 +18,7 @@ parsing machinery to work with input.
 -}
 module Parsley.Internal.Backend.Machine.InputOps (
     InputPrep(..), PositionOps(..), LogOps(..),
-    InputOps(..), more, next,
+    InputOps(..), more, next, prepareCPS,
 #if __GLASGOW_HASKELL__ <= 900
     word8ToWord#, word16ToWord#,
 #endif
@@ -74,6 +74,12 @@ type InputDependant (rep :: TYPE r) = (# {-next-} rep -> (# Char, rep #)
                                        , {-more-} rep -> Bool
                                        , {-init-} rep
                                        #)
+
+prepareCPS :: InputPrep input => Code input -> (InputOps (Rep input) -> Code (Rep input) -> Code r) -> Code r
+prepareCPS qinput k = [||
+    let (# next, more, init #) = $$(prepare qinput)
+    in $$(k (InputOps [||more||] [||next||]) [||init||])
+  ||]
 
 {- Typeclasses -}
 {-|

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/InputOps.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/InputOps.hs
@@ -75,10 +75,10 @@ type InputDependant (rep :: TYPE r) = (# {-next-} rep -> (# Char, rep #)
                                        , {-init-} rep
                                        #)
 
-prepareCPS :: InputPrep input => Code input -> (InputOps (Rep input) -> Code (Rep input) -> Code r) -> Code r
+prepareCPS :: InputPrep input => Code input -> ((?ops :: InputOps (Rep input)) => Code (Rep input) -> Code r) -> Code r
 prepareCPS qinput k = [||
     let (# next, more, init #) = $$(prepare qinput)
-    in $$(k (InputOps [||more||] [||next||]) [||init||])
+    in $$(let ?ops = InputOps [||more||] [||next||] in k [||init||])
   ||]
 
 {- Typeclasses -}

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/InputOps.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/InputOps.hs
@@ -131,9 +131,9 @@ synthesised and passed around using @ImplicitParams@.
 -}
 data InputOps (rep :: TYPE r) = InputOps { _more :: !(Code rep -> Code Bool)                                                         -- ^ Does the input have any more characters?
                                          , _next :: !(forall a. Code rep -> (Code Char -> Code rep -> Code a) -> Code a)             -- ^ Read the next character (without checking existence)
-                                         , _uncons :: (forall a. Code rep -> (Code Char -> Code rep -> Code a) -> Code a -> Code a) -- ^ Read the next character, may check existence
-                                         , _ensureN :: (forall a. Code Int# -> Code rep -> Code a -> Code a -> Code a)              -- ^ Ensure that n characters exist
-                                         , _ensureNIsFast :: !Bool                                                                    -- ^ _ensureN is O(1) and not O(n)
+                                         , _uncons :: !(forall a. Code rep -> (Code Char -> Code rep -> Code a) -> Code a -> Code a) -- ^ Read the next character, may check existence
+                                         , _ensureN :: !(forall a. Code Int# -> Code rep -> Code a -> Code a -> Code a)              -- ^ Ensure that n characters exist
+                                         , _ensureNIsFast :: !Bool                                                                   -- ^ _ensureN is O(1) and not O(n)
                                          }
 
 checkImpl :: forall r (rep :: TYPE r) a. Bool                                    -- ^ is the ensureN argument O(1)?

--- a/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/InputOps.hs
+++ b/parsley-core/src/ghc-8.10+/Parsley/Internal/Backend/Machine/InputOps.hs
@@ -37,7 +37,6 @@ import GHC.Prim                                    (word16ToWord#, word8ToWord#)
 #else
 import GHC.Prim                                    (Word#)
 #endif
-import Language.Haskell.TH.Syntax                  (liftTyped)
 import Parsley.Internal.Backend.Machine.InputRep   (Stream(..), CharList(..), Text16(..), Rep, UnpackedLazyByteString,
                                                     offWith, emptyUnpackedLazyByteString, intSame, intLess, intLess',
                                                     offsetText, offWithSame, offWithShiftRight, dropStream,
@@ -174,11 +173,10 @@ to the continuation.
 next :: forall r (rep :: TYPE r) a. (?ops :: InputOps rep) => Code rep -> (Code Char -> Code rep -> Code a) -> Code a
 next = _next ?ops
 
-check :: forall r (rep :: TYPE r) a. (?ops :: InputOps rep, PositionOps rep) => Int -> Int -> Code rep -> ([(Code Char, Code rep)] -> Code a) -> Code a -> Code a
-check _ m =
-  checkImpl False (\(I# n) qi good bad -> [|| if $$(more (shiftRight qi (liftTyped (n -# 1#)))) then $$good else $$bad ||])
-                  (\qi good bad -> [|| if $$(more qi) then $$(next qi good) else $$bad ||])
-            m m
+check :: forall r (rep :: TYPE r) a. (?ops :: InputOps rep) => Int -> Int -> Code rep -> ([(Code Char, Code rep)] -> Code a) -> Code a -> Code a
+check = checkImpl (_ensureNIsFast ?ops)
+                  (\(I# n) -> _ensureN ?ops [||n||])
+                  (_uncons ?ops)
 
 {- INSTANCES -}
 -- InputPrep Instances

--- a/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/InputOps.hs
+++ b/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/InputOps.hs
@@ -10,12 +10,11 @@ module Parsley.Internal.Backend.Machine.InputOps (
 
 import Data.Array.Base                           (UArray(..), listArray)
 import Data.ByteString.Internal                  (ByteString(..))
-import Data.Text.Array                           (aBA{-, empty-})
 import Data.Text.Internal                        (Text(..))
 import Data.Text.Unsafe                          (iter, Iter(..){-, iter_, reverseIter_-})
 import GHC.Exts                                  (Int(..), Char(..))
 import GHC.ForeignPtr                            (ForeignPtr(..))
-import GHC.Prim                                  (indexWideCharArray#, indexWord16Array#, readWord8OffAddr#, word2Int#, chr#, touch#, realWorld#, plusAddr#, (+#))
+import GHC.Prim                                  (indexWideCharArray#, readWord8OffAddr#, word2Int#, chr#, touch#, realWorld#, plusAddr#, (+#))
 import Parsley.Internal.Backend.Machine.InputRep
 import Parsley.Internal.Common.Utils             (Code)
 import Parsley.Internal.Core.InputTypes          (Stream((:>)), CharList(..), Text16(..))
@@ -63,13 +62,7 @@ instance InputPrep (UArray Int Char) where
       in InputDependant next (< size) 0
     ||]
 
-instance InputPrep Text16 where
-  prepare qinput = [||
-      let Text16 (Text arr off size) = $$qinput
-          arr# = aBA arr
-          next (I# i#) = (# C# (chr# (word2Int# (indexWord16Array# arr# i#))), I# (i# +# 1#) #)
-      in InputDependant next (< size) off
-    ||]
+instance InputPrep Text16 where prepare qinput = prepare @Text [|| let Text16 t = $$qinput in t ||]
 
 instance InputPrep ByteString where
   prepare qinput = [||

--- a/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/InputRep.hs
+++ b/parsley-core/src/ghc-8.6+/Parsley/Internal/Backend/Machine/InputRep.hs
@@ -52,7 +52,7 @@ emptyUnpackedLazyByteString i = UnpackedLazyByteString i nullAddr# (error "nullF
 type family Rep input where
   Rep [Char] = Int
   Rep (UArray Int Char) = Int
-  Rep Text16 = Int
+  Rep Text16 = Text
   Rep ByteString = Int
   Rep CharList = OffWith String
   Rep Text = Text

--- a/parsley-core/src/ghc/Parsley/Internal/Core/InputTypes.hs
+++ b/parsley-core/src/ghc/Parsley/Internal/Core/InputTypes.hs
@@ -21,6 +21,7 @@ characters.
 
 @since 0.1.0.0
 -}
+{-# DEPRECATED Text16 "Text16 is not legal with the UTF-8 encoding of Text, use Text instead" #-}
 newtype Text16 = Text16 Text
 
 --newtype CacheText = CacheText Text

--- a/parsley/src/ghc/Parsley.hs
+++ b/parsley/src/ghc/Parsley.hs
@@ -29,7 +29,6 @@ module Parsley (
 
 import Prelude hiding            (readFile)
 import Data.Text.IO              (readFile)
-import Parsley.InputExtras       (Text16(..))
 import Parsley.Internal          (Input, Trace(trace))
 
 import Parsley.Alternative              as Alternative
@@ -77,7 +76,7 @@ parse = Internal.parse
 
 {-|
 This function generates a function that reads input from a file
-and parses it. The input files contents are treated as `Text16`.
+and parses it. The input files contents are treated as `Text`.
 
 See `parse` for more information.
 
@@ -86,7 +85,7 @@ See `parse` for more information.
 parseFromFile :: Trace
               => Parser a                        -- ^ The parser to be compiled
               -> Code (FilePath -> IO (Maybe a)) -- ^ The generated parsing function
-parseFromFile p = [||\filename -> do input <- readFile filename; return ($$(parse p) (Text16 input))||]
+parseFromFile p = [||\filename -> do input <- readFile filename; return ($$(parse p) input)||]
 
 {-|
 The default instance for `Trace`, which disables all debugging output about the parser compilation


### PR DESCRIPTION
Improved the binding time of input, which should reduce the amount of code GHC has to deal with somewhat. This also allows for the construction of some improved operations for interacting with input fetching -- this will be useful on #46. 

There is further work that can be done here, since a static/dynamic `Rep` for input can be made and used to further optimise the operations: this will come soon too.

As a by-product, this PR fixes #45, though it does not _remove_ `Text16`, it changes it to just act like `Text`, making it entirely benign: `Text16` itself will be deprecated.